### PR TITLE
Use the workspace name for labels in macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A fuzz test is specified using a [`cc_fuzz_test` rule](/docs/cc-fuzzing-rules.md
 ```python
 # BUILD file.
 
-load("//fuzzing:cc_deps.bzl", "cc_fuzz_test")
+load("@rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
 
 cc_fuzz_test(
     name = "re2_fuzz_test",

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -39,7 +39,7 @@ def cc_fuzz_test(
     """
 
     binary_kwargs.setdefault("tags", []).append("fuzz-test")
-    binary_kwargs.setdefault("deps", []).append("//fuzzing:cc_engine")
+    binary_kwargs.setdefault("deps", []).append("@rules_fuzzing//fuzzing:cc_engine")
     cc_test(
         name = name,
         **binary_kwargs
@@ -63,7 +63,7 @@ def cc_fuzz_test(
 
     fuzzing_launcher(
         name = name + "_run",
-        engine = "//fuzzing:cc_engine",
+        engine = "@rules_fuzzing//fuzzing:cc_engine",
         binary = name,
         corpus = name + "_corpus" if corpus else None,
         dictionary = name + "_dict" if dicts else None,


### PR DESCRIPTION
This ensures that the label is resolved correctly regardless of the place the macro is instantiated.