### PR TITLE
Expand the documentation of the cc_fuzz_test macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,20 @@ Add the following to your `WORKSPACE` file:
 
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
-        name = "rules_fuzzing",
-        sha256 = "8901c2438fb94b55b160e82dd14a8fc3c208f948497822946319c60939c34c4f",
-        strip_prefix = "bazel-rules-fuzzing-bc4b3afc59a56cec8c61f964efa93fa81e3eb6a8",
-        urls = ["https://github.com/googleinterns/bazel-rules-fuzzing/archive/bc4b3afc59a56cec8c61f964efa93fa81e3eb6a8.zip"],
+    name = "rules_fuzzing",
+    sha256 = "a1cde2a5ccc05bdeb75bd0f4c62c6df966134a50278492468bd03ea8ffcaa133",
+    strip_prefix = "rules_fuzzing-4de19aafba32cd586abf1bd66ebd3f8d2ea98350",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/4de19aafba32cd586abf1bd66ebd3f8d2ea98350.zip"],
 )
+
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
 rules_fuzzing_dependencies()
 
 load("@rules_fuzzing//fuzzing:dependency_imports.bzl", "fuzzing_dependency_imports")
+
 fuzzing_dependency_imports()
 ```
 

--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -29,16 +29,27 @@ Specifies a fuzzing engine that can be used to run C++ fuzz targets.
 ## cc_fuzz_test
 
 <pre>
-cc_fuzz_test(<a href="#cc_fuzz_test-name">name</a>, <a href="#cc_fuzz_test-corpus">corpus</a>, <a href="#cc_fuzz_test-dicts">dicts</a>, <a href="#cc_fuzz_test-binary_kwargs">binary_kwargs</a>)
+cc_fuzz_test(<a href="#cc_fuzz_test-name">name</a>, <a href="#cc_fuzz_test-corpus">corpus</a>, <a href="#cc_fuzz_test-dicts">dicts</a>, <a href="#cc_fuzz_test-engine">engine</a>, <a href="#cc_fuzz_test-binary_kwargs">binary_kwargs</a>)
 </pre>
 
-Macro for c++ fuzzing test
+Defines a fuzz test and a few associated tools and metadata.
 
-This macro provides below targets:
-<name>: the executable file built by cc_test.
-<name>_run: an executable to launch the fuzz test.
-<name>_corpus: a target to generate a directory containing all corpus files if the argument corpus is passed.
-<name>_corpus_zip: an target to generate a zip file containing corpus files if the argument corpus is passed.
+For each fuzz test `<name>`, this macro expands into a number of targets:
+
+* `<name>`: The instrumented fuzz test executable. Use this target for
+  debugging or for accessing the complete command line interface of the
+  fuzzing engine. Most developers should only need to use this target
+  rarely.
+* `<name>_run`: An executable target used to launch the fuzz test using a
+  simpler, engine-agnostic command line interface.
+* `<name>_corpus`: Generates a corpus directory containing all the corpus
+  files specified in the `corpus` attribute.
+* `<name>_corpus_zip`: Generates a zip archive of the corpus directory.
+* `<name>_dict`: Validates the set of dictionary files provided and emits
+  the result to a `<name>.dict` file.
+
+> TODO: Document here the command line interface of the `<name>_run`
+targets.
 
 
 **PARAMETERS**
@@ -49,6 +60,7 @@ This macro provides below targets:
 | <a id="cc_fuzz_test-name"></a>name |  A unique name for this target. Required.   |  none |
 | <a id="cc_fuzz_test-corpus"></a>corpus |  A list containing corpus files.   |  <code>None</code> |
 | <a id="cc_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  <code>None</code> |
-| <a id="cc_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test binary rule.   |  none |
+| <a id="cc_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  <code>"@rules_fuzzing//fuzzing:cc_engine"</code> |
+| <a id="cc_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test   binary rule.   |  none |
 
 


### PR DESCRIPTION
~I was not yet able to regenerate the Markdown documentation due to #83.~

PR #85 should fix #83 and I was now able to re-generate the documentation in this PR.