### PR TITLE
Move the libfuzzer linkopts to the stub cc_library, such that only the top-level fuzz test is instrumented.

### DIFF
--- a/fuzzing/engines/BUILD
+++ b/fuzzing/engines/BUILD
@@ -29,6 +29,11 @@ cc_fuzzing_engine(
 cc_library(
     name = "libfuzzer_stub",
     srcs = ["libfuzzer_stub.cc"],
+    linkopts = [
+        # We add the linker options to the library, so only the fuzz test binary
+        # is linked with libfuzzer.
+        "-fsanitize=fuzzer",
+    ],
 )
 
 # Honggfuzz specification.

--- a/fuzzing/engines/libfuzzer_stub.cc
+++ b/fuzzing/engines/libfuzzer_stub.cc
@@ -12,5 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(sbucur): Implement here weak main() function that prints an error
-// signaling that the real libFuzzer engine was not linked correctly.
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" int main(int argc, char** argv) __attribute__((weak));
+
+int main(int argc, char** argv) {
+  fprintf(stderr, "*** ERROR *** This is a stub *** ERROR ***\n");
+  fprintf(stderr,
+          " * You have attempted to build a libFuzzer fuzz test, but did not "
+          "link in the fuzzing engine.\n");
+  fprintf(stderr, " * Use the '-fsanitizer=fuzzer' linker option instead.\n");
+  abort();
+}

--- a/fuzzing/engines/libfuzzer_stub.cc
+++ b/fuzzing/engines/libfuzzer_stub.cc
@@ -22,6 +22,6 @@ int main(int argc, char** argv) {
   fprintf(stderr,
           " * You have attempted to build a libFuzzer fuzz test, but did not "
           "link in the fuzzing engine.\n");
-  fprintf(stderr, " * Use the '-fsanitizer=fuzzer' linker option instead.\n");
+  fprintf(stderr, " * Use the '-fsanitize=fuzzer' linker option instead.\n");
   abort();
 }

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -51,7 +51,6 @@ def instrumentation_opts(copts = [], linkopts = []):
 # Base instrumentation applied to all fuzz test executables.
 base_opts = instrumentation_opts(
     copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"],
-    linkopts = [],
 )
 
 # Engine-specific instrumentation.
@@ -59,7 +58,6 @@ fuzzing_engine_opts = {
     "none": instrumentation_opts(),
     "libfuzzer": instrumentation_opts(
         copts = ["-fsanitize=fuzzer"],
-        linkopts = ["-fsanitize=fuzzer"],
     ),
     # Reflects the set of options at
     # https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -57,7 +57,7 @@ base_opts = instrumentation_opts(
 fuzzing_engine_opts = {
     "none": instrumentation_opts(),
     "libfuzzer": instrumentation_opts(
-        copts = ["-fsanitize=fuzzer"],
+        copts = ["-fsanitize=fuzzer-no-link"],
     ),
     # Reflects the set of options at
     # https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c


### PR DESCRIPTION
Without this change, any other binary that may be built on the transitive dependency chain will also get linked with libFuzzer, resulting in a linker error (duplicate main functions).