### PR TITLE
Fix a number of instrumentation issues that occur when other projects use the fuzzing rules.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,25 +18,25 @@ build --action_env=CXX=clang++
 
 # LibFuzzer + ASAN
 build:asan-libfuzzer --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
-build:asan-libfuzzer --//fuzzing:cc_engine_instrumentation=libfuzzer
-build:asan-libfuzzer --//fuzzing:cc_engine_sanitizer=asan
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
 # LibFuzzer + MSAN
 build:msan-libfuzzer --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
-build:msan-libfuzzer --//fuzzing:cc_engine_instrumentation=libfuzzer
-build:msan-libfuzzer --//fuzzing:cc_engine_sanitizer=msan
+build:msan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:msan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=msan
 
 # LibFuzzer + MSAN (reproduction mode)
 build:msan-libfuzzer-repro --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
-build:msan-libfuzzer-repro --//fuzzing:cc_engine_instrumentation=libfuzzer
-build:msan-libfuzzer-repro --//fuzzing:cc_engine_sanitizer=msan-origin-tracking
+build:msan-libfuzzer-repro --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:msan-libfuzzer-repro --@rules_fuzzing//fuzzing:cc_engine_sanitizer=msan-origin-tracking
 
 # Honggfuzz + ASAN
 build:asan-honggfuzz --//fuzzing:cc_engine=//fuzzing/engines:honggfuzz
-build:asan-honggfuzz --//fuzzing:cc_engine_instrumentation=honggfuzz
-build:asan-honggfuzz --//fuzzing:cc_engine_sanitizer=asan
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
 # Honggfuzz + MSAN
 build:msan-honggfuzz --//fuzzing:cc_engine=//fuzzing/engines:honggfuzz
-build:msan-honggfuzz --//fuzzing:cc_engine_instrumentation=honggfuzz
-build:msan-honggfuzz --//fuzzing:cc_engine_sanitizer=msan
+build:msan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+build:msan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=msan

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The project is still under active development, so you many need to change the `u
 
 ### Configuring the .bazelrc file
 
-Each fuzz test is built with a fuzzing engine and instrumentation specified in three build settings, available as flags on the Bazel command line:
+Each fuzz test is built with a fuzzing engine and instrumentation specified in a number of build settings, available as flags on the Bazel command line. The most common are:
 
 * `--@rules_fuzzing//fuzzing:cc_engine` points to the `cc_fuzzing_engine` target of the fuzzing engine to use.
 * `--@rules_fuzzing//fuzzing:cc_engine_instrumentation` specifies the compiler instrumentation to use (for example, libFuzzer or Honggfuzz).

--- a/fuzzing/BUILD
+++ b/fuzzing/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 label_flag(
     name = "cc_engine",
@@ -47,6 +47,16 @@ string_flag(
         # Useful for debugging crash reproducers, 1.5-2x slower.
         "msan-origin-tracking",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# If set, define the FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION macro
+# during compilation.
+#
+# See https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode
+bool_flag(
+    name = "cc_fuzzing_build_mode",
+    build_setting_default = True,
     visibility = ["//visibility:public"],
 )
 

--- a/fuzzing/engines/BUILD
+++ b/fuzzing/engines/BUILD
@@ -29,6 +29,11 @@ cc_fuzzing_engine(
 cc_library(
     name = "libfuzzer_stub",
     srcs = ["libfuzzer_stub.cc"],
+    linkopts = [
+        # We add the linker options to the library, so only the fuzz test binary
+        # is linked with libfuzzer.
+        "-fsanitize=fuzzer",
+    ],
 )
 
 # Honggfuzz specification.

--- a/fuzzing/engines/libfuzzer_stub.cc
+++ b/fuzzing/engines/libfuzzer_stub.cc
@@ -12,5 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(sbucur): Implement here weak main() function that prints an error
-// signaling that the real libFuzzer engine was not linked correctly.
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" int main(int argc, char** argv) __attribute__((weak));
+
+int main(int argc, char** argv) {
+  fprintf(stderr, "*** ERROR *** This is a stub *** ERROR ***\n");
+  fprintf(stderr,
+          " * You have attempted to build a libFuzzer fuzz test, but did not "
+          "link in the fuzzing engine.\n");
+  fprintf(stderr, " * Use the '-fsanitizer=fuzzer' linker option instead.\n");
+  abort();
+}

--- a/fuzzing/engines/libfuzzer_stub.cc
+++ b/fuzzing/engines/libfuzzer_stub.cc
@@ -22,6 +22,6 @@ int main(int argc, char** argv) {
   fprintf(stderr,
           " * You have attempted to build a libFuzzer fuzz test, but did not "
           "link in the fuzzing engine.\n");
-  fprintf(stderr, " * Use the '-fsanitizer=fuzzer' linker option instead.\n");
+  fprintf(stderr, " * Use the '-fsanitize=fuzzer' linker option instead.\n");
   abort();
 }

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -48,8 +48,10 @@ def instrumentation_opts(copts = [], linkopts = []):
         linkopts = linkopts,
     )
 
-# Base instrumentation applied to all fuzz test executables.
-base_opts = instrumentation_opts(
+# Instrumentation applied to all fuzz test executables when built in fuzzing
+# mode. This mode is controlled by the `//fuzzing:cc_fuzzing_build_mode` config
+# flag.
+fuzzing_build_opts = instrumentation_opts(
     copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"],
 )
 

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -51,7 +51,6 @@ def instrumentation_opts(copts = [], linkopts = []):
 # Base instrumentation applied to all fuzz test executables.
 base_opts = instrumentation_opts(
     copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"],
-    linkopts = [],
 )
 
 # Engine-specific instrumentation.
@@ -59,7 +58,6 @@ fuzzing_engine_opts = {
     "none": instrumentation_opts(),
     "libfuzzer": instrumentation_opts(
         copts = ["-fsanitize=fuzzer"],
-        linkopts = ["-fsanitize=fuzzer"],
     ),
     # Reflects the set of options at
     # https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -57,7 +57,7 @@ base_opts = instrumentation_opts(
 fuzzing_engine_opts = {
     "none": instrumentation_opts(),
     "libfuzzer": instrumentation_opts(
-        copts = ["-fsanitize=fuzzer"],
+        copts = ["-fsanitize=fuzzer-no-link"],
     ),
     # Reflects the set of options at
     # https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c

--- a/fuzzing/private/instrument.bzl
+++ b/fuzzing/private/instrument.bzl
@@ -16,7 +16,7 @@
 
 load(
     "//fuzzing:instrum_opts.bzl",
-    "base_opts",
+    "fuzzing_build_opts",
     "fuzzing_engine_opts",
     "instrumentation_opts",
     "sanitizer_opts",
@@ -33,15 +33,18 @@ def _fuzzing_binary_transition_impl(settings, attr):
         copts = settings["//command_line_option:copt"],
         linkopts = settings["//command_line_option:linkopt"],
     )
-    opts = _merge_opts(opts, base_opts)
 
-    engine = settings["//fuzzing:cc_engine_instrumentation"]
+    is_fuzzing_build_mode = settings["@rules_fuzzing//fuzzing:cc_fuzzing_build_mode"]
+    if is_fuzzing_build_mode:
+        opts = _merge_opts(opts, fuzzing_build_opts)
+
+    engine = settings["@rules_fuzzing//fuzzing:cc_engine_instrumentation"]
     if engine in fuzzing_engine_opts:
         opts = _merge_opts(opts, fuzzing_engine_opts[engine])
     else:
         fail("unsupported engine instrumentation '%s'" % engine)
 
-    sanitizer = settings["//fuzzing:cc_engine_sanitizer"]
+    sanitizer = settings["@rules_fuzzing//fuzzing:cc_engine_sanitizer"]
     if sanitizer in sanitizer_opts:
         opts = _merge_opts(opts, sanitizer_opts[sanitizer])
     else:
@@ -63,8 +66,9 @@ def _fuzzing_binary_transition_impl(settings, attr):
 fuzzing_binary_transition = transition(
     implementation = _fuzzing_binary_transition_impl,
     inputs = [
-        "//fuzzing:cc_engine_instrumentation",
-        "//fuzzing:cc_engine_sanitizer",
+        "@rules_fuzzing//fuzzing:cc_engine_instrumentation",
+        "@rules_fuzzing//fuzzing:cc_engine_sanitizer",
+        "@rules_fuzzing//fuzzing:cc_fuzzing_build_mode",
         "//command_line_option:copt",
         "//command_line_option:linkopt",
     ],


### PR DESCRIPTION
* The build flags need to be referenced with the absolute workspace name, so the names resolve correctly when imported in a different repo.
* The fuzzing build mode is now optional so it can be disabled in the projects that wish so.