### PR TITLE
Add support for C-only and C++-only instrumentation options.

### DIFF
--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -26,13 +26,21 @@ def _is_string_list(value):
         return False
     return True
 
-def instrumentation_opts(copts = [], linkopts = []):
+def instrumentation_opts(
+        copts = [],
+        conlyopts = [],
+        cxxopts = [],
+        linkopts = []):
     """Creates new instrumentation options.
 
     The struct fields mirror the argument names of this function.
 
     Args:
-      copts: A list of compilation options to pass as `--copt`
+      copts: A list of C/C++ compilation options passed as `--copt`
+        configuration flags.
+      conlyopts: A list of C-only compilation options passed as `--conlyopt`
+        configuration flags.
+      cxxopts: A list of C++-only compilation options passed as `--cxxopts`
         configuration flags.
       linkopts: A list of linker options to pass as `--linkopt`
         configuration flags.
@@ -41,10 +49,16 @@ def instrumentation_opts(copts = [], linkopts = []):
     """
     if not _is_string_list(copts):
         fail("copts should be a list of strings")
+    if not _is_string_list(conlyopts):
+        fail("conlyopts should be a list of strings")
+    if not _is_string_list(cxxopts):
+        fail("cxxopts should be a list of strings")
     if not _is_string_list(linkopts):
         fail("linkopts should be a list of strings")
     return struct(
         copts = copts,
+        conlyopts = conlyopts,
+        cxxopts = cxxopts,
         linkopts = linkopts,
     )
 

--- a/fuzzing/private/instrument.bzl
+++ b/fuzzing/private/instrument.bzl
@@ -25,12 +25,16 @@ load(
 def _merge_opts(left_opts, right_opts):
     return instrumentation_opts(
         copts = left_opts.copts + right_opts.copts,
+        conlyopts = left_opts.conlyopts + right_opts.conlyopts,
+        cxxopts = left_opts.cxxopts + right_opts.cxxopts,
         linkopts = left_opts.linkopts + right_opts.linkopts,
     )
 
 def _fuzzing_binary_transition_impl(settings, attr):
     opts = instrumentation_opts(
         copts = settings["//command_line_option:copt"],
+        conlyopts = settings["//command_line_option:conlyopt"],
+        cxxopts = settings["//command_line_option:cxxopt"],
         linkopts = settings["//command_line_option:linkopt"],
     )
 
@@ -58,6 +62,8 @@ def _fuzzing_binary_transition_impl(settings, attr):
     return {
         "//command_line_option:copt": opts.copts,
         "//command_line_option:linkopt": opts.linkopts,
+        "//command_line_option:conlyopt": opts.conlyopts,
+        "//command_line_option:cxxopt": opts.cxxopts,
         # Make sure binaries are built statically, to maximize the scope of the
         # instrumentation.
         "//command_line_option:dynamic_mode": "off",
@@ -70,10 +76,14 @@ fuzzing_binary_transition = transition(
         "@rules_fuzzing//fuzzing:cc_engine_sanitizer",
         "@rules_fuzzing//fuzzing:cc_fuzzing_build_mode",
         "//command_line_option:copt",
+        "//command_line_option:conlyopt",
+        "//command_line_option:cxxopt",
         "//command_line_option:linkopt",
     ],
     outputs = [
         "//command_line_option:copt",
+        "//command_line_option:conlyopt",
+        "//command_line_option:cxxopt",
         "//command_line_option:linkopt",
         "//command_line_option:dynamic_mode",
     ],


### PR DESCRIPTION
These are needed to support importing CFLAGS and CXXFLAGS from the environment, as a prerequisite for adding OSS-Fuzz support.