### PR TITLE
Remove the <name>_corpus_zip rule and its deps.

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -34,14 +34,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "rules_pkg",
-    srcs = [
-        "@rules_pkg//:path.bzl",
-        "@rules_pkg//:pkg.bzl",
-    ],
-)
-
-bzl_library(
     name = "cc_fuzzing_rules",
     srcs = [
         "//fuzzing:cc_deps.bzl",
@@ -53,7 +45,6 @@ bzl_library(
     ],
     deps = [
         ":rules_cc",
-        ":rules_pkg",
     ],
 )
 

--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -44,7 +44,6 @@ For each fuzz test `<name>`, this macro expands into a number of targets:
   simpler, engine-agnostic command line interface.
 * `<name>_corpus`: Generates a corpus directory containing all the corpus
   files specified in the `corpus` attribute.
-* `<name>_corpus_zip`: Generates a zip archive of the corpus directory.
 * `<name>_dict`: Validates the set of dictionary files provided and emits
   the result to a `<name>.dict` file.
 * `<name>_raw`: The raw, uninstrumented fuzz test executable. This should be

--- a/fuzzing/dependency_imports.bzl
+++ b/fuzzing/dependency_imports.bzl
@@ -16,13 +16,11 @@
 
 load("@rules_python//python:pip.bzl", "pip_install")
 load("@rules_python//python:repositories.bzl", "py_repositories")
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 def fuzzing_dependency_imports():
     """Imports the dependencies of the external repositories."""
     py_repositories()
-    rules_pkg_dependencies()
     bazel_skylib_workspace()
 
     pip_install(

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -15,7 +15,6 @@
 """The implementation of the cc_fuzz_test rule."""
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("//fuzzing/private:common.bzl", "fuzzing_corpus", "fuzzing_dictionary", "fuzzing_launcher")
 load("//fuzzing/private:instrument.bzl", "instrumented_fuzzing_binary")
 
@@ -38,7 +37,6 @@ def cc_fuzz_test(
       simpler, engine-agnostic command line interface.
     * `<name>_corpus`: Generates a corpus directory containing all the corpus
       files specified in the `corpus` attribute.
-    * `<name>_corpus_zip`: Generates a zip archive of the corpus directory.
     * `<name>_dict`: Validates the set of dictionary files provided and emits
       the result to a `<name>.dict` file.
     * `<name>_raw`: The raw, uninstrumented fuzz test executable. This should be
@@ -80,10 +78,6 @@ def cc_fuzz_test(
         fuzzing_corpus(
             name = name + "_corpus",
             srcs = corpus,
-        )
-        pkg_zip(
-            name = name + "_corpus_zip",
-            srcs = [name + "_corpus"],
         )
     if dicts:
         fuzzing_dictionary(

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -18,18 +18,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def rules_fuzzing_dependencies():
+    """Instantiates the dependencies of the fuzzing rules."""
+
     maybe(
         http_archive,
         name = "rules_python",
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
         sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
-    )
-
-    maybe(
-        http_archive,
-        name = "rules_pkg",
-        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
-        sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
     )
 
     maybe(


### PR DESCRIPTION
The rule is currently unused and will be superseded by other rules creating their own corpus ZIP archive.