### PR TITLE
Make the corpus directory always contain files, even if just an empty file.

### DIFF
--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -56,6 +56,7 @@ def cc_fuzz_test(
           binary rule.
     """
 
+    corpus_name = name + "_corpus"
     binary_kwargs.setdefault("deps", []).append(engine)
     cc_test(
         name = name + "_raw",
@@ -69,7 +70,7 @@ def cc_fuzz_test(
         name = name,
         binary = name + "_raw",
         engine = engine,
-        corpus = name + "_corpus" if corpus else None,
+        corpus = corpus_name,
         dictionary = name + "_dict" if dicts else None,
         tags = (tags or []) + [
             "fuzz-test",
@@ -77,11 +78,10 @@ def cc_fuzz_test(
         testonly = True,
     )
 
-    if corpus:
-        fuzzing_corpus(
-            name = name + "_corpus",
-            srcs = corpus,
-        )
+    fuzzing_corpus(
+        name = corpus_name,
+        srcs = corpus,
+    )
     if dicts:
         fuzzing_dictionary(
             name = name + "_dict",

--- a/fuzzing/tools/make_corpus_dir.py
+++ b/fuzzing/tools/make_corpus_dir.py
@@ -49,14 +49,17 @@ def main(argv):
         else:
             expanded_file_list.append(corpus)
     
-    for corpus in expanded_file_list:
-        dest = os.path.join(FLAGS.output_dir, corpus.replace("/", "-"))
-        # Whatever the separator we choose, there is an chance that
-        # the dest name conflicts with another file
-        if os.path.exists(dest):
-            print("ERROR: file " + dest + " existed.", file=stderr)
-            return -1
-        shutil.copy(corpus, dest)
+    if expanded_file_list:
+        for corpus in expanded_file_list:
+            dest = os.path.join(FLAGS.output_dir, corpus.replace("/", "-"))
+            # Whatever the separator we choose, there is an chance that
+            # the dest name conflicts with another file
+            if os.path.exists(dest):
+                print("ERROR: file " + dest + " existed.", file=stderr)
+                return -1
+            shutil.copy(corpus, dest)
+    else:
+        open(os.path.join(FLAGS.output_dir, "empty_test"), "a").close()
     return 0
 
 


### PR DESCRIPTION
This prevents a Bazel glitch in which the corpus directory is absent from the fuzz target runfiles if the directory is empty. It also simplifies the downstream logic handling the corpus directory.