### PR TITLE
Refactor the cc_fuzzing_engine implementation to use more precise naming.

### DIFF
--- a/fuzzing/engines/BUILD
+++ b/fuzzing/engines/BUILD
@@ -41,11 +41,11 @@ cc_library(
 
 cc_fuzzing_engine(
     name = "honggfuzz",
-    data = {
-        "@honggfuzz//:honggfuzz": "HONGGFUZZ_PATH",
-    },
     display_name = "Honggfuzz",
     launcher = "honggfuzz_launcher.sh",
+    launcher_data = {
+        "@honggfuzz//:honggfuzz": "HONGGFUZZ_PATH",
+    },
     library = "@honggfuzz//:honggfuzz_engine",
     visibility = ["//visibility:public"],
 )

--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -33,7 +33,7 @@ exec "{launcher}" \
     script_content = script_template.format(
         environment = "\n".join([
             "export %s='%s'" % (var, file.short_path)
-            for var, file in binary_info.engine_info.environment.items()
+            for var, file in binary_info.engine_info.launcher_environment.items()
         ]),
         launcher = ctx.executable._launcher.short_path,
         binary_path = ctx.executable.binary.short_path,
@@ -49,8 +49,8 @@ def _fuzzing_launcher_impl(ctx):
     script = _fuzzing_launcher_script(ctx)
 
     binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
-    runfiles = ctx.runfiles(files = [binary_info.engine_info.launcher])
-    runfiles = runfiles.merge(binary_info.engine_info.runfiles)
+    runfiles = ctx.runfiles()
+    runfiles = runfiles.merge(binary_info.engine_info.launcher_runfiles)
     runfiles = runfiles.merge(ctx.attr._launcher[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(ctx.attr.binary[DefaultInfo].default_runfiles)
     return [DefaultInfo(executable = script, runfiles = runfiles)]

--- a/fuzzing/private/engine.bzl
+++ b/fuzzing/private/engine.bzl
@@ -20,10 +20,10 @@ Provider for storing the specification of a fuzzing engine.
 """,
     fields = {
         "display_name": "A string representing the human-readable name of the fuzzing engine.",
-        "cc_library_info": "A CcInfo provider for the C++ library of the fuzzing engine.",
-        "runfiles": "The runfiles of the fuzzing engine.",
+        "engine_library_info": "A CcInfo provider for the C++ library of the fuzzing engine.",
         "launcher": "A file representing the shell script that launches the fuzz target.",
-        "environment": "A dictionary from environment variables to files.",
+        "launcher_runfiles": "The runfiles needed by the launcher script on the fuzzing engine side, such as helper tools and their data dependencies.",
+        "launcher_environment": "A dictionary from environment variables to files used by the launcher script.",
     },
 )
 
@@ -31,27 +31,27 @@ def _cc_fuzzing_engine_impl(ctx):
     if not ctx.attr.display_name:
         fail("The display_name attribute of the rule must not be empty.")
 
-    runfiles = ctx.runfiles()
+    launcher_runfiles = ctx.runfiles(files = [ctx.file.launcher])
     env_vars = {}
-    for data, env_var in ctx.attr.data.items():
-        if env_var:
-            if env_var in env_vars:
-                fail("Multiple data dependencies map to variable '%s'." % env_var)
-            data_files = data.files.to_list()
+    for data_label, data_env_var in ctx.attr.launcher_data.items():
+        if data_env_var:
+            if data_env_var in env_vars:
+                fail("Multiple data dependencies map to variable '%s'." % data_env_var)
+            data_files = data_label.files.to_list()
             if len(data_files) != 1:
-                fail("Data dependency for variable '%s' doesn't map to exactly one file." % env_var)
-            env_vars[env_var] = data_files[0]
-        runfiles = runfiles.merge(data[DefaultInfo].default_runfiles)
+                fail("Data dependency for variable '%s' doesn't map to exactly one file." % data_env_var)
+            env_vars[data_env_var] = data_files[0]
+        launcher_runfiles = launcher_runfiles.merge(data_label[DefaultInfo].default_runfiles)
 
     cc_library_info = ctx.attr.library[CcInfo]
     cc_fuzzing_engine_info = CcFuzzingEngineInfo(
         display_name = ctx.attr.display_name,
-        cc_library_info = cc_library_info,
-        runfiles = runfiles,
+        engine_library_info = cc_library_info,
         launcher = ctx.file.launcher,
-        environment = env_vars,
+        launcher_runfiles = launcher_runfiles,
+        launcher_environment = env_vars,
     )
-    return [cc_library_info, cc_fuzzing_engine_info]
+    return [ctx.attr.library[DefaultInfo], cc_library_info, cc_fuzzing_engine_info]
 
 cc_fuzzing_engine = rule(
     implementation = _cc_fuzzing_engine_impl,
@@ -76,7 +76,7 @@ Specifies a fuzzing engine that can be used to run C++ fuzz targets.
             mandatory = True,
             allow_single_file = True,
         ),
-        "data": attr.label_keyed_string_dict(
+        "launcher_data": attr.label_keyed_string_dict(
             doc = "A dict mapping additional runtime dependencies needed by " +
                   "the fuzzing engine to environment variables that will be " +
                   "available inside the launcher, holding the runtime path " +

--- a/fuzzing/private/engine.bzl
+++ b/fuzzing/private/engine.bzl
@@ -34,13 +34,14 @@ def _cc_fuzzing_engine_impl(ctx):
     launcher_runfiles = ctx.runfiles(files = [ctx.file.launcher])
     env_vars = {}
     for data_label, data_env_var in ctx.attr.launcher_data.items():
+        data_files = data_label.files.to_list()
         if data_env_var:
             if data_env_var in env_vars:
                 fail("Multiple data dependencies map to variable '%s'." % data_env_var)
-            data_files = data_label.files.to_list()
             if len(data_files) != 1:
                 fail("Data dependency for variable '%s' doesn't map to exactly one file." % data_env_var)
             env_vars[data_env_var] = data_files[0]
+        launcher_runfiles = launcher_runfiles.merge(ctx.runfiles(files = data_files))
         launcher_runfiles = launcher_runfiles.merge(data_label[DefaultInfo].default_runfiles)
 
     cc_library_info = ctx.attr.library[CcInfo]

--- a/fuzzing/private/engine_test.bzl
+++ b/fuzzing/private/engine_test.bzl
@@ -72,15 +72,24 @@ def _provider_contents_test_impl(ctx):
     )
     asserts.set_equals(
         env,
-        sets.make([]),
-        sets.make(target_under_test[CcFuzzingEngineInfo].runfiles.files.to_list()),
+        sets.make([
+            "fuzzing/private/launcher_stub.sh",
+            "fuzzing/private/data.txt",
+            "fuzzing/private/anon_data.txt",
+        ]),
+        sets.make([
+            file.short_path
+            for file in target_under_test[CcFuzzingEngineInfo].launcher_runfiles.files.to_list()
+        ]),
     )
     asserts.set_equals(
         env,
-        sets.make([("DATA_STUB_FILE", "fuzzing/private/data.txt")]),
+        sets.make([
+            ("DATA_STUB_FILE", "fuzzing/private/data.txt"),
+        ]),
         sets.make([
             (env_var, file.short_path)
-            for env_var, file in target_under_test[CcFuzzingEngineInfo].environment.items()
+            for env_var, file in target_under_test[CcFuzzingEngineInfo].launcher_environment.items()
         ]),
     )
     return analysistest.end(env)
@@ -94,7 +103,7 @@ def _test_provider_contents():
         display_name = "Provider Contents",
         library = ":library_stub",
         launcher = ":launcher_stub",
-        data = {
+        launcher_data = {
             ":data_stub": "DATA_STUB_FILE",
             ":anon_data_stub": "",
         },


### PR DESCRIPTION
The goal is to establish more clearly the relationship between the launcher script, its runfiles, and the environment variables available.