### PR TITLE
Implement the regression mode flag in the libFuzzer and Honggfuzz launchers.

### DIFF
--- a/fuzzing/engines/honggfuzz_launcher.sh
+++ b/fuzzing/engines/honggfuzz_launcher.sh
@@ -21,6 +21,12 @@ if [[ -n "${FUZZER_SEED_CORPUS_DIR}" ]]; then
 else
     command_line+=("--input=${FUZZER_OUTPUT_CORPUS_DIR}")
 fi
+if (( FUZZER_IS_REGRESSION )); then
+    # There is no regression mode in Honggfuzz, use minimization to a
+    # temporary output as the closest proxy.
+    command_line+=("--minimize")
+    command_line+=("--verbose")
+fi
 
 command_line+=("--crashdir=${FUZZER_ARTIFACTS_DIR}")
 

--- a/fuzzing/engines/libfuzzer_launcher.sh
+++ b/fuzzing/engines/libfuzzer_launcher.sh
@@ -27,6 +27,9 @@ command_line+=("-artifact_prefix=${FUZZER_ARTIFACTS_DIR}/")
 if [[ "${FUZZER_TIMEOUT_SECS}" -gt 0 ]]; then
     command_line+=("-max_total_time=${FUZZER_TIMEOUT_SECS}")
 fi
+if (( FUZZER_IS_REGRESSION )); then
+    command_line+=("-runs=0")
+fi
 
 # Corpus sources.
 


### PR DESCRIPTION
This is a prerequisite for adding "regression unit test" support.