### PR TITLE
Add a test rule for running a fuzz test against the seed corpus.

### DIFF
--- a/.github/workflows/bazel_test.yml
+++ b/.github/workflows/bazel_test.yml
@@ -30,11 +30,9 @@ jobs:
       - name: Run Address Sanitizer tests
         run: |
           bazel test //... --test_tag_filters=-fuzz-test --build_tests_only --config=asan
-      - name: Build fuzz test examples
-        # The -FDP is for filtering out the files which contains "#include <fuzzer/FuzzedDataProvider.h>",
-        # The "<fuzzer/FDP...>" is only supported since clang-10 while the clang version in github runner is 9
+      - name: Run fuzz test regressions
         run: |
-          bazel build --verbose_failures --build_tag_filters=fuzz-test,-FDP --config=asan-libfuzzer //examples/...
+          bazel test --verbose_failures --build_tag_filters=fuzz-test --config=asan-libfuzzer //examples/...
   smoke_tests:
     name: Smoke tests on fuzz targets
     runs-on: ubuntu-latest

--- a/.github/workflows/bazel_test.yml
+++ b/.github/workflows/bazel_test.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Run unit tests
         run: |
-          bazel test //... --test_tag_filters=-fuzz-test --build_tests_only
+          bazel test --test_tag_filters=-fuzz-test --build_tests_only //...
       - name: Run Address Sanitizer tests
         run: |
-          bazel test //... --test_tag_filters=-fuzz-test --build_tests_only --config=asan
+          bazel test --test_tag_filters=-fuzz-test --build_tests_only --config=asan //...
       - name: Run fuzz test regressions
         run: |
           bazel test --verbose_failures --build_tag_filters=fuzz-test --config=asan-libfuzzer //examples/...

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -43,6 +43,7 @@ bzl_library(
         "//fuzzing/private:engine.bzl",
         "//fuzzing/private:fuzz_test.bzl",
         "//fuzzing/private:instrum_opts.bzl",
+        "//fuzzing/private:regression.bzl",
         "//fuzzing/private/oss_fuzz:package.bzl",
         "@rules_fuzzing_oss_fuzz//:instrum.bzl",
     ],

--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -5,7 +5,7 @@
 ## cc_fuzzing_engine
 
 <pre>
-cc_fuzzing_engine(<a href="#cc_fuzzing_engine-name">name</a>, <a href="#cc_fuzzing_engine-data">data</a>, <a href="#cc_fuzzing_engine-display_name">display_name</a>, <a href="#cc_fuzzing_engine-launcher">launcher</a>, <a href="#cc_fuzzing_engine-library">library</a>)
+cc_fuzzing_engine(<a href="#cc_fuzzing_engine-name">name</a>, <a href="#cc_fuzzing_engine-display_name">display_name</a>, <a href="#cc_fuzzing_engine-launcher">launcher</a>, <a href="#cc_fuzzing_engine-launcher_data">launcher_data</a>, <a href="#cc_fuzzing_engine-library">library</a>)
 </pre>
 
 
@@ -18,9 +18,9 @@ Specifies a fuzzing engine that can be used to run C++ fuzz targets.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="cc_fuzzing_engine-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="cc_fuzzing_engine-data"></a>data |  A dict mapping additional runtime dependencies needed by the fuzzing engine to environment variables that will be available inside the launcher, holding the runtime path to the dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
 | <a id="cc_fuzzing_engine-display_name"></a>display_name |  The name of the fuzzing engine, as it should be rendered in human-readable output.   | String | required |  |
 | <a id="cc_fuzzing_engine-launcher"></a>launcher |  A shell script that knows how to launch the fuzzing executable based on configuration specified in the environment.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="cc_fuzzing_engine-launcher_data"></a>launcher_data |  A dict mapping additional runtime dependencies needed by the fuzzing engine to environment variables that will be available inside the launcher, holding the runtime path to the dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
 | <a id="cc_fuzzing_engine-library"></a>library |  A cc_library target that implements the fuzzing engine entry point.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
@@ -34,21 +34,17 @@ cc_fuzz_test(<a href="#cc_fuzz_test-name">name</a>, <a href="#cc_fuzz_test-corpu
 
 Defines a fuzz test and a few associated tools and metadata.
 
-For each fuzz test `<name>`, this macro expands into a number of targets:
+For each fuzz test `<name>`, this macro defines a number of targets. The
+most relevant ones are:
 
-* `<name>`: The instrumented fuzz test executable. Use this target for
-  debugging or for accessing the complete command line interface of the
+* `<name>`: A test that executes the fuzzer binary against the seed corpus
+  (or on an empty input if no corpus is specified).
+* `<name>_instrum`: The instrumented fuzz test executable. Use this target
+  for debugging or for accessing the complete command line interface of the
   fuzzing engine. Most developers should only need to use this target
   rarely.
 * `<name>_run`: An executable target used to launch the fuzz test using a
   simpler, engine-agnostic command line interface.
-* `<name>_corpus`: Generates a corpus directory containing all the corpus
-  files specified in the `corpus` attribute.
-* `<name>_dict`: Validates the set of dictionary files provided and emits
-  the result to a `<name>.dict` file.
-* `<name>_raw`: The raw, uninstrumented fuzz test executable. This should be
-  rarely needed and may be useful when debugging instrumentation-related
-  build failures or misbehavior.
 
 > TODO: Document here the command line interface of the `<name>_run`
 targets.

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -53,12 +53,17 @@ cc_fuzz_test(
 cc_fuzz_test(
     name = "fuzzed_data_provider_fuzz_test",
     srcs = ["fuzzed_data_provider_fuzz_test.cc"],
-    tags = ["FDP"],
+    tags = [
+        "manual",
+    ],
 )
 
 cc_fuzz_test(
     name = "hang_fuzz_test",
     srcs = ["hang_fuzz_test.cc"],
+    tags = [
+        "manual",
+    ],
 )
 
 cc_fuzz_test(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -54,6 +54,8 @@ cc_fuzz_test(
     name = "fuzzed_data_provider_fuzz_test",
     srcs = ["fuzzed_data_provider_fuzz_test.cc"],
     tags = [
+        # Disable this test for now, since FDP is not available on all
+        # supported Clang versions.
         "manual",
     ],
 )
@@ -86,6 +88,9 @@ cc_fuzz_test(
 cc_fuzz_test(
     name = "oom_fuzz_test",
     srcs = ["oom_fuzz_test.cc"],
+    tags = [
+        "manual",
+    ],
 )
 
 cc_fuzz_test(

--- a/fuzzing/private/BUILD
+++ b/fuzzing/private/BUILD
@@ -24,4 +24,5 @@ exports_files([
     "engine.bzl",
     "fuzz_test.bzl",
     "instrum_opts.bzl",
+    "regression.bzl",
 ])

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -40,6 +40,11 @@ def cc_fuzz_test(
       rarely.
     * `<name>_run`: An executable target used to launch the fuzz test using a
       simpler, engine-agnostic command line interface.
+    * `<name>_oss_fuzz`: Generates a `<name>_oss_fuzz.tar` archive containing
+      the fuzz target executable and its associated resources (corpus,
+      dictionary, etc.) in a format suitable for unpacking in the $OUT/
+      directory of an OSS-Fuzz build. This target can be used inside the
+      `build.sh` script of an OSS-Fuzz project.
 
     > TODO: Document here the command line interface of the `<name>_run`
     targets.

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -54,6 +54,9 @@ def cc_fuzz_test(
           binary rule.
     """
 
+    # Append the '_' suffix to the raw target to dissuade users from referencing
+    # this target directly. Instead, the binary should be built through the
+    # instrumented configuration.
     raw_binary_name = name + "_raw_"
     instrum_binary_name = name + "_instrum"
     launcher_name = name + "_run"

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -29,21 +29,17 @@ def cc_fuzz_test(
         **binary_kwargs):
     """Defines a fuzz test and a few associated tools and metadata.
 
-    For each fuzz test `<name>`, this macro expands into a number of targets:
+    For each fuzz test `<name>`, this macro defines a number of targets. The
+    most relevant ones are:
 
-    * `<name>`: The instrumented fuzz test executable. Use this target for
-      debugging or for accessing the complete command line interface of the
+    * `<name>`: A test that executes the fuzzer binary against the seed corpus
+      (or on an empty input if no corpus is specified).
+    * `<name>_instrum`: The instrumented fuzz test executable. Use this target
+      for debugging or for accessing the complete command line interface of the
       fuzzing engine. Most developers should only need to use this target
       rarely.
     * `<name>_run`: An executable target used to launch the fuzz test using a
       simpler, engine-agnostic command line interface.
-    * `<name>_corpus`: Generates a corpus directory containing all the corpus
-      files specified in the `corpus` attribute.
-    * `<name>_dict`: Validates the set of dictionary files provided and emits
-      the result to a `<name>.dict` file.
-    * `<name>_raw`: The raw, uninstrumented fuzz test executable. This should be
-      rarely needed and may be useful when debugging instrumentation-related
-      build failures or misbehavior.
 
     > TODO: Document here the command line interface of the `<name>_run`
     targets.

--- a/fuzzing/private/regression.bzl
+++ b/fuzzing/private/regression.bzl
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression testing rule for fuzz tests."""
+
+load("//fuzzing/private:binary.bzl", "CcFuzzingBinaryInfo")
+
+def _fuzzing_regression_test_impl(ctx):
+    binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
+    script = ctx.actions.declare_file(ctx.label.name)
+    script_template = """
+export FUZZER_OUTPUT_CORPUS_DIR="$TEST_TMPDIR/corpus"
+export FUZZER_ARTIFACTS_DIR="$TEST_TMPDIR/artifacts"
+export FUZZER_BINARY='{fuzzer_binary}'
+export FUZZER_SEED_CORPUS_DIR='{seed_corpus_dir}'
+export FUZZER_IS_REGRESSION=1
+{engine_launcher_environment}
+
+mkdir -p "$FUZZER_OUTPUT_CORPUS_DIR"
+mkdir -p "$FUZZER_ARTIFACTS_DIR"
+
+exec '{engine_launcher}'
+"""
+    script_content = script_template.format(
+        fuzzer_binary = ctx.executable.binary.short_path,
+        seed_corpus_dir = binary_info.corpus_dir.short_path,
+        engine_launcher_environment = "\n".join([
+            "export %s='%s'" % (var, file.short_path)
+            for var, file in binary_info.engine_info.launcher_environment.items()
+        ]),
+        engine_launcher = binary_info.engine_info.launcher.short_path,
+    )
+    ctx.actions.write(script, script_content, is_executable = True)
+
+    runfiles = ctx.runfiles()
+    runfiles = runfiles.merge(ctx.attr.binary[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(binary_info.engine_info.launcher_runfiles)
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+fuzzing_regression_test = rule(
+    implementation = _fuzzing_regression_test_impl,
+    doc = """
+Executes a fuzz test on its seed corpus.
+""",
+    attrs = {
+        "binary": attr.label(
+            executable = True,
+            doc = "The instrumented executable of the fuzz test to run.",
+            providers = [CcFuzzingBinaryInfo],
+            cfg = "target",
+            mandatory = True,
+        ),
+    },
+    test = True,
+)


### PR DESCRIPTION
This is a specialization of the launcher rule, defined as a test. The cc_fuzz_test macro is also refactored such that the test rule runs by default when invoking "bazel test".