### PR TITLE
Separate the set of associated targets in a cc_fuzz_test rule in a distinct macro.

### DIFF
--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -78,7 +78,7 @@ fuzzing_decoration(<a href="#fuzzing_decoration-base_name">base_name</a>, <a hre
 
 Generates the standard targets associated to a fuzz test.
 
-This target can be used to define custom fuzz test rules in case the default
+This macro can be used to define custom fuzz test rules in case the default
 `cc_fuzz_test` macro is not adequate. Refer to the `cc_fuzz_test` macro
 documentation for the set of targets generated.
 

--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -45,6 +45,11 @@ most relevant ones are:
   rarely.
 * `<name>_run`: An executable target used to launch the fuzz test using a
   simpler, engine-agnostic command line interface.
+* `<name>_oss_fuzz`: Generates a `<name>_oss_fuzz.tar` archive containing
+  the fuzz target executable and its associated resources (corpus,
+  dictionary, etc.) in a format suitable for unpacking in the $OUT/
+  directory of an OSS-Fuzz build. This target can be used inside the
+  `build.sh` script of an OSS-Fuzz project.
 
 > TODO: Document here the command line interface of the `<name>_run`
 targets.
@@ -59,7 +64,35 @@ targets.
 | <a id="cc_fuzz_test-corpus"></a>corpus |  A list containing corpus files.   |  <code>None</code> |
 | <a id="cc_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  <code>None</code> |
 | <a id="cc_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  <code>"@rules_fuzzing//fuzzing:cc_engine"</code> |
-| <a id="cc_fuzz_test-tags"></a>tags |  Tags set on the fuzz test executable.   |  <code>None</code> |
+| <a id="cc_fuzz_test-tags"></a>tags |  Tags set on the fuzzing regression test.   |  <code>None</code> |
 | <a id="cc_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test   binary rule.   |  none |
+
+
+<a id="#fuzzing_decoration"></a>
+
+## fuzzing_decoration
+
+<pre>
+fuzzing_decoration(<a href="#fuzzing_decoration-base_name">base_name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-tags">tags</a>)
+</pre>
+
+Generates the standard targets associated to a fuzz test.
+
+This target can be used to define custom fuzz test rules in case the default
+`cc_fuzz_test` macro is not adequate. Refer to the `cc_fuzz_test` macro
+documentation for the set of targets generated.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="fuzzing_decoration-base_name"></a>base_name |  The name prefix of the generated targets. It is normally the   fuzz test name in the BUILD file.   |  none |
+| <a id="fuzzing_decoration-raw_binary"></a>raw_binary |  The label of the cc_binary or cc_test of fuzz test   executable.   |  none |
+| <a id="fuzzing_decoration-engine"></a>engine |  The label of the fuzzing engine used to build the binary.   |  none |
+| <a id="fuzzing_decoration-corpus"></a>corpus |  A list of corpus files.   |  <code>None</code> |
+| <a id="fuzzing_decoration-dicts"></a>dicts |  A list of fuzzing dictionary files.   |  <code>None</code> |
+| <a id="fuzzing_decoration-tags"></a>tags |  Tags set on the fuzzing regression test.   |  <code>None</code> |
 
 

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -21,6 +21,7 @@ change without notice.
 load(
     "//fuzzing/private:fuzz_test.bzl",
     _cc_fuzz_test = "cc_fuzz_test",
+    _fuzzing_decoration = "fuzzing_decoration",
 )
 load(
     "//fuzzing/private:engine.bzl",
@@ -29,3 +30,5 @@ load(
 
 cc_fuzz_test = _cc_fuzz_test
 cc_fuzzing_engine = _cc_fuzzing_engine
+
+fuzzing_decoration = _fuzzing_decoration

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -29,7 +29,7 @@ def fuzzing_decoration(
         tags = None):
     """Generates the standard targets associated to a fuzz test.
 
-    This target can be used to define custom fuzz test rules in case the default
+    This macro can be used to define custom fuzz test rules in case the default
     `cc_fuzz_test` macro is not adequate. Refer to the `cc_fuzz_test` macro
     documentation for the set of targets generated.
 

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -55,6 +55,7 @@ def fuzzing_decoration(
         engine = engine,
         corpus = corpus_name,
         dictionary = dict_name if dicts else None,
+        testonly = True,
     )
 
     fuzzing_corpus(
@@ -71,6 +72,7 @@ def fuzzing_decoration(
     fuzzing_launcher(
         name = launcher_name,
         binary = instrum_binary_name,
+        testonly = True,
     )
 
     fuzzing_regression_test(

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -61,12 +61,14 @@ def fuzzing_decoration(
     fuzzing_corpus(
         name = corpus_name,
         srcs = corpus,
+        testonly = True,
     )
     if dicts:
         fuzzing_dictionary(
             name = dict_name,
             dicts = dicts,
             output = base_name + ".dict",
+            testonly = True,
         )
 
     fuzzing_launcher(

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -20,6 +20,73 @@ load("//fuzzing/private:binary.bzl", "fuzzing_binary")
 load("//fuzzing/private:regression.bzl", "fuzzing_regression_test")
 load("//fuzzing/private/oss_fuzz:package.bzl", "oss_fuzz_package")
 
+def fuzzing_decoration(
+        base_name,
+        raw_binary,
+        engine,
+        corpus = None,
+        dicts = None,
+        tags = None):
+    """Generates the standard targets associated to a fuzz test.
+
+    This target can be used to define custom fuzz test rules in case the default
+    `cc_fuzz_test` macro is not adequate. Refer to the `cc_fuzz_test` macro
+    documentation for the set of targets generated.
+
+    Args:
+        base_name: The name prefix of the generated targets. It is normally the
+          fuzz test name in the BUILD file.
+        raw_binary: The label of the cc_binary or cc_test of fuzz test
+          executable.
+        engine: The label of the fuzzing engine used to build the binary.
+        corpus: A list of corpus files.
+        dicts: A list of fuzzing dictionary files.
+        tags: Tags set on the fuzzing regression test.
+    """
+
+    instrum_binary_name = base_name + "_instrum"
+    launcher_name = base_name + "_run"
+    corpus_name = base_name + "_corpus"
+    dict_name = base_name + "_dict"
+
+    fuzzing_binary(
+        name = instrum_binary_name,
+        binary = raw_binary,
+        engine = engine,
+        corpus = corpus_name,
+        dictionary = dict_name if dicts else None,
+    )
+
+    fuzzing_corpus(
+        name = corpus_name,
+        srcs = corpus,
+    )
+    if dicts:
+        fuzzing_dictionary(
+            name = dict_name,
+            dicts = dicts,
+            output = base_name + ".dict",
+        )
+
+    fuzzing_launcher(
+        name = launcher_name,
+        binary = instrum_binary_name,
+    )
+
+    fuzzing_regression_test(
+        name = base_name,
+        binary = instrum_binary_name,
+        tags = (tags or []) + [
+            "fuzz-test",
+        ],
+    )
+
+    oss_fuzz_package(
+        name = base_name + "_oss_fuzz",
+        binary = instrum_binary_name,
+        testonly = True,
+    )
+
 def cc_fuzz_test(
         name,
         corpus = None,
@@ -54,7 +121,7 @@ def cc_fuzz_test(
         corpus: A list containing corpus files.
         dicts: A list containing dictionaries.
         engine: A label pointing to the fuzzing engine to use.
-        tags: Tags set on the fuzz test executable.
+        tags: Tags set on the fuzzing regression test.
         **binary_kwargs: Keyword arguments directly forwarded to the fuzz test
           binary rule.
     """
@@ -63,50 +130,17 @@ def cc_fuzz_test(
     # this target directly. Instead, the binary should be built through the
     # instrumented configuration.
     raw_binary_name = name + "_raw_"
-    instrum_binary_name = name + "_instrum"
-    launcher_name = name + "_run"
-    corpus_name = name + "_corpus"
-
     binary_kwargs.setdefault("deps", []).append(engine)
     cc_binary(
         name = raw_binary_name,
         **binary_kwargs
     )
 
-    fuzzing_binary(
-        name = instrum_binary_name,
-        binary = raw_binary_name,
+    fuzzing_decoration(
+        base_name = name,
+        raw_binary = raw_binary_name,
         engine = engine,
-        corpus = corpus_name,
-        dictionary = name + "_dict" if dicts else None,
-    )
-
-    fuzzing_corpus(
-        name = corpus_name,
-        srcs = corpus,
-    )
-    if dicts:
-        fuzzing_dictionary(
-            name = name + "_dict",
-            dicts = dicts,
-            output = name + ".dict",
-        )
-
-    fuzzing_launcher(
-        name = launcher_name,
-        binary = instrum_binary_name,
-    )
-
-    fuzzing_regression_test(
-        name = name,
-        binary = instrum_binary_name,
-        tags = (tags or []) + [
-            "fuzz-test",
-        ],
-    )
-
-    oss_fuzz_package(
-        name = name + "_oss_fuzz",
-        binary = instrum_binary_name,
-        testonly = True,
+        corpus = corpus,
+        dicts = dicts,
+        tags = tags,
     )

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -76,9 +76,7 @@ def fuzzing_decoration(
     fuzzing_regression_test(
         name = base_name,
         binary = instrum_binary_name,
-        tags = (tags or []) + [
-            "fuzz-test",
-        ],
+        tags = tags,
     )
 
     oss_fuzz_package(
@@ -142,5 +140,7 @@ def cc_fuzz_test(
         engine = engine,
         corpus = corpus,
         dicts = dicts,
-        tags = tags,
+        tags = (tags or []) + [
+            "fuzz-test",
+        ],
     )


### PR DESCRIPTION
The macro can be instantiated in custom definitions of the cc_fuzz_test macro.