### PR TITLE
Fix the base name of the OSS-Fuzz targets.

### DIFF
--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -85,6 +85,7 @@ def fuzzing_decoration(
 
     oss_fuzz_package(
         name = base_name + "_oss_fuzz",
+        base_name = base_name,
         binary = instrum_binary_name,
         testonly = True,
     )

--- a/fuzzing/private/oss_fuzz/package.bzl
+++ b/fuzzing/private/oss_fuzz/package.bzl
@@ -42,7 +42,7 @@ def _oss_fuzz_package_impl(ctx):
             fi
             tar -chf "{output}" -C "$STAGING_DIR" .
         """.format(
-            base_name = ctx.executable.binary.basename,
+            base_name = ctx.attr.base_name,
             binary_path = binary_info.binary_file.path,
             corpus_dir = binary_info.corpus_dir.path if binary_info.corpus_dir else "",
             dictionary_path = binary_info.dictionary_file.path if binary_info.dictionary_file else "",
@@ -66,6 +66,11 @@ Packages a fuzz test in a TAR archive compatible with the OSS-Fuzz format.
             providers = [CcFuzzingBinaryInfo],
             mandatory = True,
             cfg = "target",
+        ),
+        "base_name": attr.string(
+            doc = "The base name of the fuzz test used to form the file names " +
+                  "in the OSS-Fuzz output.",
+            mandatory = True,
         ),
     },
 )


### PR DESCRIPTION
For a `cc_fuzz_test(name = <name>)` target, the base name used in the OSS-Fuzz package should be `<name>`, rather than the internal name of the instrumented binary.

Tested this is working correctly:

```
$ bazel build //examples:re2_fuzz_test_oss_fuzz
INFO: Analyzed target //examples:re2_fuzz_test_oss_fuzz (1 packages loaded, 52 targets configured).
INFO: Found 1 target...
Target //examples:re2_fuzz_test_oss_fuzz up-to-date:
  bazel-bin/examples/re2_fuzz_test_oss_fuzz.tar
INFO: Elapsed time: 2.222s, Critical Path: 1.45s
INFO: 30 processes: 4 internal, 26 linux-sandbox.
INFO: Build completed successfully, 30 total actions

$ tar -tvf bazel-bin/examples/re2_fuzz_test_oss_fuzz.tar
drwxr-xr-x sbucur/primarygroup 0 2021-01-25 22:21 ./
-rw-r--r-- sbucur/primarygroup 170 2021-01-25 22:21 ./re2_fuzz_test_seed_corpus.zip
-r-xr-xr-x sbucur/primarygroup 1812648 2021-01-25 22:21 ./re2_fuzz_test
```