### PR TITLE
Pin the hashes of all Python requirements.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,7 @@ py_repositories()
 
 pip_install(
     name = "fuzzing_py_deps",
+    extra_pip_args = ["--require-hashes"],
     requirements = "@rules_fuzzing//fuzzing:requirements.txt",
 )
 

--- a/fuzzing/requirements.txt
+++ b/fuzzing/requirements.txt
@@ -1,4 +1,5 @@
 # Python requirements for the tools supporting the fuzzing rules. These are
 # installed automatically through the WORKSPACE configuration.
 
-absl-py==0.11.0
+absl-py==0.11.0 --hash=sha256:b3d9eb5119ff6e0a0125f6dabf2f9fae02f8acae7be70576002fac27235611c5
+six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced


### PR DESCRIPTION
This helps the fuzzing rules be consistent with Envoy's dependency policies (envoyproxy/envoy#14834).