### PR TITLE
Fix OSX build

### DIFF
--- a/fuzzing/replay/BUILD
+++ b/fuzzing/replay/BUILD
@@ -33,9 +33,15 @@ cc_library(
     ],
 )
 
+WEAK_LLVM_FUZZER_INITIALIZE = select({
+    "@platforms//os:osx": ["-Wl,-U,_LLVMFuzzerInitialize"],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "replay_main",
     srcs = ["replay_main.cc"],
+    linkopts = WEAK_LLVM_FUZZER_INITIALIZE,
     deps = [
         ":test_replayer",
         "@com_google_absl//absl/status",

--- a/fuzzing/replay/replay_main.cc
+++ b/fuzzing/replay/replay_main.cc
@@ -22,7 +22,7 @@
 
 extern "C" {
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
-int LLVMFuzzerInitialize(int* argc, char*** argv) __attribute__((weak));
+int LLVMFuzzerInitialize(int* argc, char*** argv) __attribute__((weak_import));
 }
 
 namespace {


### PR DESCRIPTION
 * more portable strerror_r handling (borrowed from abseil)
 * adjust honggfuzz build options
 * notify linker about weak ref in :replay_main

See https://github.com/bazelbuild/rules_fuzzing/issues/138