### PR TITLE
Improve dict validation

### DIFF
--- a/examples/dictionaries/valid_part1.dict
+++ b/examples/dictionaries/valid_part1.dict
@@ -6,7 +6,7 @@ kw1="blah"
 # Use \\ for backslash and \" for quotes.
 kw2="\"ac\\dc\""
 # Use \xAB for hex values
-kw3="\xF7\xF8""
+kw3="\xF7\xF8"
 # the name of the keyword followed by '=' may be omitted:
 "foo\x0Abar"
 "ab\""

--- a/fuzzing/tools/dict_validation_test.py
+++ b/fuzzing/tools/dict_validation_test.py
@@ -28,7 +28,6 @@ class DictValidatorTest(unittest.TestCase):
         self.assertTrue(validate_line('":path"'))
         self.assertTrue(validate_line('"keep-alive"'))
         self.assertTrue(validate_line('"te"'))
-        self.assertTrue(validate_line('"ab""'))
 
     def test_escaped_words(self):
         self.assertTrue(validate_line('kw2="\\"ac\\\\dc\\""'))
@@ -38,8 +37,22 @@ class DictValidatorTest(unittest.TestCase):
     def test_invalid_escaped_words(self):
         self.assertFalse(validate_line('"\\A"'))
 
+    def test_unfinished_escape(self):
+        self.assertFalse(validate_line('"\\"'))
+        self.assertFalse(validate_line('"\\x"'))
+        self.assertFalse(validate_line('"\\x1"'))
+
+    def test_invalid_unescaped_words(self):
+        self.assertFalse(validate_line('"""'))
+
     def test_comment(self):
         self.assertTrue(validate_line('# valid dictionary entries'))
+
+    def test_suffix_after_entry(self):
+        self.assertFalse(validate_line('"entry"suffix'))
+
+    def test_empty_entry(self):
+        self.assertFalse(validate_line('""'))
 
     def test_empty_string(self):
         self.assertTrue(validate_line(''))

--- a/fuzzing/tools/validate_dict.py
+++ b/fuzzing/tools/validate_dict.py
@@ -33,10 +33,11 @@ flags.DEFINE_string("output_file", "",
 
 def validate_dict(dict_path, output_stream):
     with open(dict_path, 'r') as dict:
-        for line in dict.readlines():
+        for index, line in enumerate(dict.readlines()):
             line = line.strip()
             if not validate_line(line):
-                print("ERROR: invalid dictionary entry '%s'" % line,
+                print("ERROR: invalid dictionary entry '%s' in %s:%d" %
+                      (line, dict_path, index + 1),
                       file=stderr)
                 return False
             if output_stream:


### PR DESCRIPTION
Refactor dict validation using regular expression for simplification and improvement.
After the change, the validation will:

 - Disallow `"\"`, `""`, and any non-space suffix after the entry ends (e.g. `"entry"suffix`).
 - Disallow unesacped '"' in enties. Raw '"' can indeed be used in libFuzzer due to implementation details,
   but it is undocumented (https://llvm.org/docs/LibFuzzer.html#dictionaries), implementation-dependent, and confusing.
 - Show file paths and line numbers with errors.

Fixes #47 