### PR TITLE
Decompose FuzzingEngineInfo into orthogonal providers

### DIFF
--- a/fuzzing/private/binary.bzl
+++ b/fuzzing/private/binary.bzl
@@ -26,7 +26,7 @@ load(
     "sanitizer_configs",
 )
 
-CcFuzzingBinaryInfo = provider(
+FuzzingBinaryInfo = provider(
     doc = """
 Provider for storing information about a fuzz test binary.
 """,
@@ -115,7 +115,7 @@ def _fuzzing_binary_impl(ctx):
             executable = output_file,
             runfiles = binary_runfiles.merge(ctx.runfiles(files = other_runfiles)),
         ),
-        CcFuzzingBinaryInfo(
+        FuzzingBinaryInfo(
             binary_file = ctx.executable.binary,
             binary_runfiles = binary_runfiles,
             corpus_dir = ctx.file.corpus,
@@ -166,7 +166,7 @@ The instrumentation is controlled by the following flags:
         ),
     },
     executable = True,
-    provides = [CcFuzzingBinaryInfo],
+    provides = [FuzzingBinaryInfo],
 )
 
 fuzzing_binary_uninstrumented = rule(
@@ -203,5 +203,5 @@ be incorporated in the target configuration (e.g., on the command line or the
         ),
     },
     executable = True,
-    provides = [CcFuzzingBinaryInfo],
+    provides = [FuzzingBinaryInfo],
 )

--- a/fuzzing/private/binary.bzl
+++ b/fuzzing/private/binary.bzl
@@ -14,7 +14,7 @@
 
 """Defines a rule for creating an instrumented fuzzing executable."""
 
-load("//fuzzing/private:engine.bzl", "CcFuzzingEngineInfo")
+load("//fuzzing/private:engine.bzl", "FuzzingEngineInfo")
 load(
     "//fuzzing/private:instrum_opts.bzl",
     "instrum_defaults",
@@ -35,7 +35,7 @@ Provider for storing information about a fuzz test binary.
         "binary_runfiles": "The runfiles of the fuzz test executable.",
         "corpus_dir": "The directory of the corpus files used as input seeds.",
         "dictionary_file": "The dictionary file to use in fuzzing runs.",
-        "engine_info": "The `CcFuzzingEngineInfo` provider of the fuzzing engine used in the fuzz test.",
+        "engine_info": "The `FuzzingEngineInfo` provider of the fuzzing engine used in the fuzz test.",
     },
 )
 
@@ -120,7 +120,7 @@ def _fuzzing_binary_impl(ctx):
             binary_runfiles = binary_runfiles,
             corpus_dir = ctx.file.corpus,
             dictionary_file = ctx.file.dictionary,
-            engine_info = ctx.attr.engine[CcFuzzingEngineInfo],
+            engine_info = ctx.attr.engine[FuzzingEngineInfo],
         ),
     ]
 
@@ -147,7 +147,7 @@ The instrumentation is controlled by the following flags:
         ),
         "engine": attr.label(
             doc = "The specification of the fuzzing engine used in the binary.",
-            providers = [CcFuzzingEngineInfo],
+            providers = [FuzzingEngineInfo],
             mandatory = True,
         ),
         "corpus": attr.label(
@@ -187,7 +187,7 @@ be incorporated in the target configuration (e.g., on the command line or the
         ),
         "engine": attr.label(
             doc = "The specification of the fuzzing engine used in the binary.",
-            providers = [CcFuzzingEngineInfo],
+            providers = [FuzzingEngineInfo],
             mandatory = True,
         ),
         "corpus": attr.label(

--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -14,10 +14,10 @@
 
 """Common building blocks for fuzz test definitions."""
 
-load("//fuzzing/private:binary.bzl", "CcFuzzingBinaryInfo")
+load("//fuzzing/private:binary.bzl", "FuzzingBinaryInfo")
 
 def _fuzzing_launcher_script(ctx):
-    binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
+    binary_info = ctx.attr.binary[FuzzingBinaryInfo]
     script = ctx.actions.declare_file(ctx.label.name)
 
     script_template = """
@@ -48,7 +48,7 @@ exec "{launcher}" \
 def _fuzzing_launcher_impl(ctx):
     script = _fuzzing_launcher_script(ctx)
 
-    binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
+    binary_info = ctx.attr.binary[FuzzingBinaryInfo]
     runfiles = ctx.runfiles()
     runfiles = runfiles.merge(binary_info.engine_info.launcher_runfiles)
     runfiles = runfiles.merge(ctx.attr._launcher[DefaultInfo].default_runfiles)
@@ -70,7 +70,7 @@ Rule for creating a script to run the fuzzing test.
         "binary": attr.label(
             executable = True,
             doc = "The executable of the fuzz test to run.",
-            providers = [CcFuzzingBinaryInfo],
+            providers = [FuzzingBinaryInfo],
             cfg = "target",
             mandatory = True,
         ),

--- a/fuzzing/private/engine.bzl
+++ b/fuzzing/private/engine.bzl
@@ -14,20 +14,19 @@
 
 """The implementation of the cc_fuzzing_engine rule."""
 
-CcFuzzingEngineInfo = provider(
+FuzzingEngineInfo = provider(
     doc = """
 Provider for storing the specification of a fuzzing engine.
 """,
     fields = {
         "display_name": "A string representing the human-readable name of the fuzzing engine.",
-        "engine_library_info": "A CcInfo provider for the C++ library of the fuzzing engine.",
         "launcher": "A file representing the shell script that launches the fuzz target.",
         "launcher_runfiles": "The runfiles needed by the launcher script on the fuzzing engine side, such as helper tools and their data dependencies.",
         "launcher_environment": "A dictionary from environment variables to files used by the launcher script.",
     },
 )
 
-def _cc_fuzzing_engine_impl(ctx):
+def _make_fuzzing_engine_info(ctx):
     if not ctx.attr.display_name:
         fail("The display_name attribute of the rule must not be empty.")
 
@@ -44,15 +43,19 @@ def _cc_fuzzing_engine_impl(ctx):
         launcher_runfiles = launcher_runfiles.merge(ctx.runfiles(files = data_files))
         launcher_runfiles = launcher_runfiles.merge(data_label[DefaultInfo].default_runfiles)
 
-    cc_library_info = ctx.attr.library[CcInfo]
-    cc_fuzzing_engine_info = CcFuzzingEngineInfo(
+    return FuzzingEngineInfo(
         display_name = ctx.attr.display_name,
-        engine_library_info = cc_library_info,
         launcher = ctx.file.launcher,
         launcher_runfiles = launcher_runfiles,
         launcher_environment = env_vars,
     )
-    return [ctx.attr.library[DefaultInfo], cc_library_info, cc_fuzzing_engine_info]
+
+def _cc_fuzzing_engine_impl(ctx):
+    return [
+        _make_fuzzing_engine_info(ctx),
+        ctx.attr.library[DefaultInfo],
+        ctx.attr.library[CcInfo],
+    ]
 
 cc_fuzzing_engine = rule(
     implementation = _cc_fuzzing_engine_impl,
@@ -85,5 +88,5 @@ Specifies a fuzzing engine that can be used to run C++ fuzz targets.
             allow_files = True,
         ),
     },
-    provides = [CcFuzzingEngineInfo],
+    provides = [CcInfo, FuzzingEngineInfo],
 )

--- a/fuzzing/private/engine_test.bzl
+++ b/fuzzing/private/engine_test.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
-load(":engine.bzl", "CcFuzzingEngineInfo", "cc_fuzzing_engine")
+load(":engine.bzl", "FuzzingEngineInfo", "cc_fuzzing_engine")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(":util.bzl", "generate_file")
 
@@ -50,7 +50,7 @@ def _setup_common_stubs():
         testonly = 1,
     )
 
-# Test that the CcFuzzingEngineInfo provider is populated correctly
+# Test that the FuzzingEngineInfo provider is populated correctly
 # (`provider_contents` stem).
 
 def _provider_contents_test_impl(ctx):
@@ -63,12 +63,12 @@ def _provider_contents_test_impl(ctx):
     asserts.equals(
         env,
         "Provider Contents",
-        target_under_test[CcFuzzingEngineInfo].display_name,
+        target_under_test[FuzzingEngineInfo].display_name,
     )
     asserts.equals(
         env,
         "fuzzing/private/launcher_stub.sh",
-        target_under_test[CcFuzzingEngineInfo].launcher.short_path,
+        target_under_test[FuzzingEngineInfo].launcher.short_path,
     )
     asserts.set_equals(
         env,
@@ -79,7 +79,7 @@ def _provider_contents_test_impl(ctx):
         ]),
         sets.make([
             file.short_path
-            for file in target_under_test[CcFuzzingEngineInfo].launcher_runfiles.files.to_list()
+            for file in target_under_test[FuzzingEngineInfo].launcher_runfiles.files.to_list()
         ]),
     )
     asserts.set_equals(
@@ -89,7 +89,7 @@ def _provider_contents_test_impl(ctx):
         ]),
         sets.make([
             (env_var, file.short_path)
-            for env_var, file in target_under_test[CcFuzzingEngineInfo].launcher_environment.items()
+            for env_var, file in target_under_test[FuzzingEngineInfo].launcher_environment.items()
         ]),
     )
     return analysistest.end(env)

--- a/fuzzing/private/oss_fuzz/package.bzl
+++ b/fuzzing/private/oss_fuzz/package.bzl
@@ -14,11 +14,11 @@
 
 """Rule for packaging fuzz tests in the expected OSS-Fuzz format."""
 
-load("//fuzzing/private:binary.bzl", "CcFuzzingBinaryInfo")
+load("//fuzzing/private:binary.bzl", "FuzzingBinaryInfo")
 
 def _oss_fuzz_package_impl(ctx):
     output_archive = ctx.actions.declare_file(ctx.label.name + ".tar")
-    binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
+    binary_info = ctx.attr.binary[FuzzingBinaryInfo]
 
     action_inputs = [binary_info.binary_file]
     if binary_info.corpus_dir:
@@ -66,7 +66,7 @@ Packages a fuzz test in a TAR archive compatible with the OSS-Fuzz format.
         "binary": attr.label(
             executable = True,
             doc = "The fuzz test executable.",
-            providers = [CcFuzzingBinaryInfo],
+            providers = [FuzzingBinaryInfo],
             mandatory = True,
             cfg = "target",
         ),

--- a/fuzzing/private/regression.bzl
+++ b/fuzzing/private/regression.bzl
@@ -14,10 +14,10 @@
 
 """Regression testing rule for fuzz tests."""
 
-load("//fuzzing/private:binary.bzl", "CcFuzzingBinaryInfo")
+load("//fuzzing/private:binary.bzl", "FuzzingBinaryInfo")
 
 def _fuzzing_regression_test_impl(ctx):
-    binary_info = ctx.attr.binary[CcFuzzingBinaryInfo]
+    binary_info = ctx.attr.binary[FuzzingBinaryInfo]
     script = ctx.actions.declare_file(ctx.label.name)
     script_template = """
 export FUZZER_OUTPUT_CORPUS_DIR="$TEST_TMPDIR/corpus"
@@ -57,7 +57,7 @@ Executes a fuzz test on its seed corpus.
         "binary": attr.label(
             executable = True,
             doc = "The instrumented executable of the fuzz test to run.",
-            providers = [CcFuzzingBinaryInfo],
+            providers = [FuzzingBinaryInfo],
             cfg = "target",
             mandatory = True,
         ),


### PR DESCRIPTION
By removing the engine_library_info field of CcFuzzingEngineInfo and relying exlusively on the DefaultInfo and language-specific *Info providers to propagate the information about the engine library, CcFuzzingEngineInfo can become almost completely generic in the language.

This PR performs the required refactoring and renames the provider to FuzzingEngineInfo. It also drops the Cc prefix of CcFuzzingBinaryInfo, which no longer depends on the language.