### PR TITLE
Prepare Java release

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -69,3 +69,33 @@ stardoc(
         ":cc_fuzzing_rules",
     ],
 )
+
+bzl_library(
+    name = "java_fuzzing_rules",
+    srcs = [
+        "//fuzzing:instrum_opts.bzl",
+        "//fuzzing:java_defs.bzl",
+        "//fuzzing/private:binary.bzl",
+        "//fuzzing/private:common.bzl",
+        "//fuzzing/private:engine.bzl",
+        "//fuzzing/private:fuzz_test.bzl",
+        "//fuzzing/private:instrum_opts.bzl",
+        "//fuzzing/private:java_utils.bzl",
+        "//fuzzing/private:regression.bzl",
+        "//fuzzing/private/oss_fuzz:package.bzl",
+        "@rules_fuzzing_oss_fuzz//:instrum.bzl",
+    ],
+    deps = [
+        ":bazel_skylib",
+        ":rules_cc",
+    ],
+)
+
+stardoc(
+    name = "java_fuzzing_docs",
+    out = "java-fuzzing-rules.md",
+    input = "//fuzzing:java_defs.bzl",
+    deps = [
+        ":java_fuzzing_rules",
+    ],
+)

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -41,10 +41,11 @@ bzl_library(
 )
 
 bzl_library(
-    name = "cc_fuzzing_rules",
+    name = "fuzzing_rules",
     srcs = [
         "//fuzzing:cc_defs.bzl",
         "//fuzzing:instrum_opts.bzl",
+        "//fuzzing:java_defs.bzl",
         "//fuzzing/private:binary.bzl",
         "//fuzzing/private:common.bzl",
         "//fuzzing/private:engine.bzl",
@@ -66,28 +67,7 @@ stardoc(
     out = "cc-fuzzing-rules.md",
     input = "//fuzzing:cc_defs.bzl",
     deps = [
-        ":cc_fuzzing_rules",
-    ],
-)
-
-bzl_library(
-    name = "java_fuzzing_rules",
-    srcs = [
-        "//fuzzing:instrum_opts.bzl",
-        "//fuzzing:java_defs.bzl",
-        "//fuzzing/private:binary.bzl",
-        "//fuzzing/private:common.bzl",
-        "//fuzzing/private:engine.bzl",
-        "//fuzzing/private:fuzz_test.bzl",
-        "//fuzzing/private:instrum_opts.bzl",
-        "//fuzzing/private:java_utils.bzl",
-        "//fuzzing/private:regression.bzl",
-        "//fuzzing/private/oss_fuzz:package.bzl",
-        "@rules_fuzzing_oss_fuzz//:instrum.bzl",
-    ],
-    deps = [
-        ":bazel_skylib",
-        ":rules_cc",
+        ":fuzzing_rules",
     ],
 )
 
@@ -96,6 +76,6 @@ stardoc(
     out = "java-fuzzing-rules.md",
     input = "//fuzzing:java_defs.bzl",
     deps = [
-        ":java_fuzzing_rules",
+        ":fuzzing_rules",
     ],
 )

--- a/docs/java-fuzzing-rules.md
+++ b/docs/java-fuzzing-rules.md
@@ -1,0 +1,97 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a id="#java_fuzzing_engine"></a>
+
+## java_fuzzing_engine
+
+<pre>
+java_fuzzing_engine(<a href="#java_fuzzing_engine-name">name</a>, <a href="#java_fuzzing_engine-display_name">display_name</a>, <a href="#java_fuzzing_engine-launcher">launcher</a>, <a href="#java_fuzzing_engine-launcher_data">launcher_data</a>, <a href="#java_fuzzing_engine-library">library</a>)
+</pre>
+
+
+Specifies a fuzzing engine that can be used to run Java fuzz targets.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="java_fuzzing_engine-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="java_fuzzing_engine-display_name"></a>display_name |  The name of the fuzzing engine, as it should be rendered in human-readable output.   | String | required |  |
+| <a id="java_fuzzing_engine-launcher"></a>launcher |  A shell script that knows how to launch the fuzzing executable based on configuration specified in the environment.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="java_fuzzing_engine-launcher_data"></a>launcher_data |  A dict mapping additional runtime dependencies needed by the fuzzing engine to environment variables that will be available inside the launcher, holding the runtime path to the dependency.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="java_fuzzing_engine-library"></a>library |  A java_library target that is made available to all Java fuzz tests.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+
+
+<a id="#fuzzing_decoration"></a>
+
+## fuzzing_decoration
+
+<pre>
+fuzzing_decoration(<a href="#fuzzing_decoration-name">name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-instrument_binary">instrument_binary</a>,
+                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>)
+</pre>
+
+Generates the standard targets associated to a fuzz test.
+
+This macro can be used to define custom fuzz test rules in case the default
+`cc_fuzz_test` macro is not adequate. Refer to the `cc_fuzz_test` macro
+documentation for the set of targets generated.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="fuzzing_decoration-name"></a>name |  The name prefix of the generated targets. It is normally the   fuzz test name in the BUILD file.   |  none |
+| <a id="fuzzing_decoration-raw_binary"></a>raw_binary |  The label of the cc_binary or cc_test of fuzz test   executable.   |  none |
+| <a id="fuzzing_decoration-engine"></a>engine |  The label of the fuzzing engine used to build the binary.   |  none |
+| <a id="fuzzing_decoration-corpus"></a>corpus |  A list of corpus files.   |  <code>None</code> |
+| <a id="fuzzing_decoration-dicts"></a>dicts |  A list of fuzzing dictionary files.   |  <code>None</code> |
+| <a id="fuzzing_decoration-instrument_binary"></a>instrument_binary |  **(Experimental, may be removed in the future.)**<br><br>  By default, the generated targets depend on <code>raw_binary</code> through   a Bazel configuration using flags from the <code>@rules_fuzzing//fuzzing</code>   package to determine the fuzzing build mode, engine, and sanitizer   instrumentation.<br><br>  When this argument is false, the targets assume that <code>raw_binary</code> is   already built in the proper configuration and will not apply the   transition.<br><br>  Most users should not need to change this argument. If you think the   default instrumentation mode does not work for your use case, please   file a Github issue to discuss.   |  <code>True</code> |
+| <a id="fuzzing_decoration-define_regression_test"></a>define_regression_test |  If true, generate a regression test rule.   |  <code>True</code> |
+| <a id="fuzzing_decoration-test_tags"></a>test_tags |  Tags set on the fuzzing regression test.   |  <code>None</code> |
+
+
+<a id="#java_fuzz_test"></a>
+
+## java_fuzz_test
+
+<pre>
+java_fuzz_test(<a href="#java_fuzz_test-name">name</a>, <a href="#java_fuzz_test-srcs">srcs</a>, <a href="#java_fuzz_test-target_class">target_class</a>, <a href="#java_fuzz_test-transitive_native_deps">transitive_native_deps</a>, <a href="#java_fuzz_test-corpus">corpus</a>, <a href="#java_fuzz_test-dicts">dicts</a>, <a href="#java_fuzz_test-engine">engine</a>, <a href="#java_fuzz_test-tags">tags</a>,
+               <a href="#java_fuzz_test-binary_kwargs">binary_kwargs</a>)
+</pre>
+
+Defines a Java fuzz test and a few associated tools and metadata.
+
+For each fuzz test `<name>`, this macro defines a number of targets. The
+most relevant ones are:
+
+* `<name>`: A test that executes the fuzzer binary against the seed corpus
+  (or on an empty input if no corpus is specified).
+* `<name>_bin`: The instrumented fuzz test executable. Use this target
+  for debugging or for accessing the complete command line interface of the
+  fuzzing engine. Most developers should only need to use this target
+  rarely.
+* `<name>_run`: An executable target used to launch the fuzz test using a
+  simpler, engine-agnostic command line interface.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="java_fuzz_test-name"></a>name |  A unique name for this target. Required.   |  none |
+| <a id="java_fuzz_test-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="java_fuzz_test-target_class"></a>target_class |  The class that contains the static fuzzerTestOneInput   method. Defaults to the same class main_class would.   |  <code>None</code> |
+| <a id="java_fuzz_test-transitive_native_deps"></a>transitive_native_deps |  A list of all native libraries that the fuzz   target transitively depends on. The libraries are instrumented   automatically and do not need to be mentioned in deps. Listing the   libraries in this way is no longer required as of Bazel 5.   |  <code>None</code> |
+| <a id="java_fuzz_test-corpus"></a>corpus |  A list containing corpus files.   |  <code>None</code> |
+| <a id="java_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  <code>None</code> |
+| <a id="java_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  <code>"@rules_fuzzing//fuzzing:java_engine"</code> |
+| <a id="java_fuzz_test-tags"></a>tags |  Tags set on the fuzzing regression test.   |  <code>None</code> |
+| <a id="java_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test   binary rule.   |  none |
+
+

--- a/examples/java/com/example/JavaFuzzTest.java
+++ b/examples/java/com/example/JavaFuzzTest.java
@@ -24,8 +24,6 @@ public class JavaFuzzTest {
 
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         String input = data.consumeRemainingAsString();
-        // Without the hook in ExampleFuzzerHooks.java, the value of random would change on every
-        // invocation, making it almost impossible to guess for the fuzzer.
         if (input.startsWith("magicstring") && input.length() > 30
                 && input.charAt(25) == 'C') {
             mustNeverBeCalled();

--- a/examples/java/com/example/JavaNativeFuzzTest.cpp
+++ b/examples/java/com/example/JavaNativeFuzzTest.cpp
@@ -16,15 +16,16 @@
 
 #include <string>
 
-// simple function containing a crash that requires coverage and string compare
-// instrumentation for the fuzzer to find
+// Prevent the compiler from optimizing away the out-of-bounds read in
+// parseInternal.
+volatile int dummy = 0;
+
 void parseInternal(const std::string &input) {
   if (input[0] == 'a' && input[1] == 'b' && input[5] == 'c') {
     if (input.find("secret_in_native_library") != std::string::npos) {
-      // With ASan: Read past null byte to trigger an OOB read.
-      // Without ASan: Segfault
+      // Read past null byte to trigger an OOB read.
       if (input[input.size() + 1] != 0x12)
-          *reinterpret_cast<char *>(1) = 2;
+        dummy += 1;
     }
   }
 }

--- a/examples/java/com/example/JavaNativeFuzzTest.cpp
+++ b/examples/java/com/example/JavaNativeFuzzTest.cpp
@@ -16,16 +16,13 @@
 
 #include <string>
 
-// Prevent the compiler from optimizing away the out-of-bounds read in
-// parseInternal.
-volatile int dummy = 0;
-
-void parseInternal(const std::string &input) {
+__attribute__((optnone)) void parseInternal(const std::string &input) {
   if (input[0] == 'a' && input[1] == 'b' && input[5] == 'c') {
     if (input.find("secret_in_native_library") != std::string::npos) {
       // Read past null byte to trigger an OOB read.
-      if (input[input.size() + 1] != 0x12)
-        dummy += 1;
+      if (input[input.size() + 1] != 0x12) {
+        return;
+      }
     }
   }
 }

--- a/fuzzing/BUILD
+++ b/fuzzing/BUILD
@@ -70,5 +70,6 @@ bool_flag(
 
 exports_files([
     "cc_defs.bzl",
+    "java_defs.bzl",
     "instrum_opts.bzl",
 ])

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -242,10 +242,10 @@ def java_fuzz_test(
     if not target_class:
         target_class = determine_primary_class(srcs, name)
     if not target_class:
-        fail("Unable to determine fuzz target class for java_fuzz_test {name}" +
-             ", specify target_class".format(
-                 name = name,
-             ))
+        fail(("Unable to determine fuzz target class for java_fuzz_test {name}" +
+              ", specify target_class.").format(
+            name = name,
+        ))
     deploy_manifest_lines = [
         "Jazzer-Fuzz-Target-Class: %s" % target_class,
     ]

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -265,8 +265,8 @@ def java_fuzz_test(
         name = raw_binary_name,
         driver = select(
             {
-                "//fuzzing/private:use_sanitizer_none": "@jazzer//driver:jazzer_driver",
-                "//fuzzing/private:use_sanitizer_asan": "@jazzer//driver:jazzer_driver_asan",
+                "@rules_fuzzing//fuzzing/private:use_sanitizer_none": "@jazzer//driver:jazzer_driver",
+                "@rules_fuzzing//fuzzing/private:use_sanitizer_asan": "@jazzer//driver:jazzer_driver_asan",
             },
             no_match_error = "Jazzer only supports the sanitizer settings \"none\" and \"asan\"",
         ),

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -72,7 +72,7 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
         maybe(
             http_archive,
             name = "jazzer",
-            sha256 = "289138a0a7d6154c51b5b2407a9ae7e1b5e4c1d0ba32fe7ef2d3929cb15578aa",
-            strip_prefix = "jazzer-978ed6a05bb9408e02b2b1c88064e5851399824b",
-            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/978ed6a05bb9408e02b2b1c88064e5851399824b.zip",
+            sha256 = "797d29ceae19ce36a95f5fbfd995bca2815256c8d5f7a705e84897336a4fea61",
+            strip_prefix = "jazzer-f1c4bb507733710bbf292e474e173fcd0d6e8ff5",
+            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/f1c4bb507733710bbf292e474e173fcd0d6e8ff5.zip",
         )

--- a/update_docs.sh
+++ b/update_docs.sh
@@ -15,5 +15,5 @@
 
 set -euo pipefail
 
-bazel build //docs:cc_fuzzing_docs
-cp bazel-bin/docs/cc-fuzzing-rules.md docs/
+bazel build //docs:cc_fuzzing_docs //docs:java_fuzzing_docs
+cp bazel-bin/docs/cc-fuzzing-rules.md bazel-bin/docs/java-fuzzing-rules.md docs/


### PR DESCRIPTION
This updates Jazzer and adds Java documentation to the README and Stardoc.

@stefanbucur I have some ideas on how to implement oss-fuzz support, but I don't think this is critical for the next release - most OSS Java projects don't use Bazel. 