### PR TITLE
Use OSS-Fuzz provided top-level files

### DIFF
--- a/fuzzing/private/oss_fuzz/BUILD.tpl
+++ b/fuzzing/private/oss_fuzz/BUILD.tpl
@@ -30,5 +30,5 @@ cc_library(
 )
 
 exports_files([
-    "instrum.bzl",
+    "instrum.bzl", %{exported_files}
 ])

--- a/fuzzing/private/oss_fuzz/repository.bzl
+++ b/fuzzing/private/oss_fuzz/repository.bzl
@@ -103,12 +103,37 @@ def _extract_build_params(
         instrum_cxxopts = instrum_cxxopts,
     )
 
+# The paths under $OUT of the OSS-Fuzz provided Jazzer files.
+_JAZZER_IN_AGENT_DEPLOY_JAR = "jazzer_agent_deploy.jar"
+_JAZZER_IN_DRIVER = "jazzer_driver"
+_JAZZER_IN_DRIVER_ADDRESS_SANITIZER = "jazzer_driver_asan"
+
+# The filenames under which the OSS-Fuzz provided Jazzer files will be available
+# in this repository.
+_JAZZER_OUT_AGENT_DEPLOY_JAR = _JAZZER_IN_AGENT_DEPLOY_JAR
+_JAZZER_OUT_DRIVER_NO_SANITIZER = "jazzer_driver_no_sanitizer"
+_JAZZER_OUT_DRIVER_WITH_SANITIZER = "jazzer_driver_with_sanitizer"
+
+def _export_jazzer(repository_ctx, out_path, sanitizer):
+    if out_path == None:
+        return []
+    exported_files = []
+    repository_ctx.symlink(out_path + "/" + _JAZZER_IN_AGENT_DEPLOY_JAR, _JAZZER_OUT_AGENT_DEPLOY_JAR)
+    exported_files.append(_JAZZER_OUT_AGENT_DEPLOY_JAR)
+    repository_ctx.symlink(out_path + "/" + _JAZZER_IN_DRIVER, _JAZZER_OUT_DRIVER_NO_SANITIZER)
+    exported_files.append(_JAZZER_OUT_DRIVER_NO_SANITIZER)
+    if sanitizer == "address":
+        repository_ctx.symlink(out_path + "/" + _JAZZER_IN_DRIVER_ADDRESS_SANITIZER, _JAZZER_OUT_DRIVER_WITH_SANITIZER)
+        exported_files.append(_JAZZER_OUT_DRIVER_WITH_SANITIZER)
+    return exported_files
+
 def _oss_fuzz_repository(repository_ctx):
     environ = repository_ctx.os.environ
     fuzzing_engine_library = environ.get("LIB_FUZZING_ENGINE")
     sanitizer = environ.get("SANITIZER")
     cflags = environ.get("FUZZING_CFLAGS") or environ.get("CFLAGS", "")
     cxxflags = environ.get("FUZZING_CXXFLAGS") or environ.get("CXXFLAGS", "")
+    out_path = environ.get("OUT")
 
     build_params = _extract_build_params(
         repository_ctx,
@@ -117,6 +142,7 @@ def _oss_fuzz_repository(repository_ctx):
         cflags.split(" "),
         cxxflags.split(" "),
     )
+    exported_files = _export_jazzer(repository_ctx, out_path, sanitizer)
 
     repository_ctx.template(
         "BUILD",
@@ -124,6 +150,7 @@ def _oss_fuzz_repository(repository_ctx):
         {
             "%{stub_srcs}": _to_list_repr(build_params.stub_srcs),
             "%{stub_linkopts}": _to_list_repr(build_params.stub_linkopts),
+            "%{exported_files}": _to_list_repr(exported_files),
         },
     )
     repository_ctx.template(
@@ -148,6 +175,7 @@ oss_fuzz_repository = repository_rule(
         "CFLAGS",
         "CXXFLAGS",
         "SANITIZER",
+        "OUT",
     ],
     local = True,
     doc = """

--- a/fuzzing/private/oss_fuzz/repository.bzl
+++ b/fuzzing/private/oss_fuzz/repository.bzl
@@ -103,15 +103,24 @@ def _extract_build_params(
         instrum_cxxopts = instrum_cxxopts,
     )
 
-# The paths under $OUT of the OSS-Fuzz provided Jazzer files.
+# The filename under which the Jazzer agent is available in $OUT.
 _JAZZER_IN_AGENT_DEPLOY_JAR = "jazzer_agent_deploy.jar"
+
+# The filename under which the Jazzer agent is available in
+# @rules_fuzzing_oss_fuzz.
+_JAZZER_OUT_AGENT_DEPLOY_JAR = _JAZZER_IN_AGENT_DEPLOY_JAR
+
+# The filenames under which the Jazzer drivers with various sanitizers are
+# available in $OUT.
 _JAZZER_IN_DRIVER = "jazzer_driver"
 _JAZZER_IN_DRIVER_ADDRESS_SANITIZER = "jazzer_driver_asan"
 
-# The filenames under which the OSS-Fuzz provided Jazzer files will be available
-# in this repository.
-_JAZZER_OUT_AGENT_DEPLOY_JAR = _JAZZER_IN_AGENT_DEPLOY_JAR
+# The filename under which the Jazzer driver for Java-only projects is available
+# in @rules_fuzzing_oss_fuzz.
 _JAZZER_OUT_DRIVER_NO_SANITIZER = "jazzer_driver_no_sanitizer"
+
+# The filename under which the Jazzer driver with the sanitizer specified by
+# $SANITIZER is available in @rules_fuzzing_oss_fuzz.
 _JAZZER_OUT_DRIVER_WITH_SANITIZER = "jazzer_driver_with_sanitizer"
 
 def _export_jazzer(repository_ctx, out_path, sanitizer):


### PR DESCRIPTION
OSS-Fuzz provides certain files for use by all fuzz targets depending on the language declared in the project.yaml, e.g. the Jazzer driver and agent. These files should be used instead of building them themselves, primarily because this allows seemless updates to the fuzzing engines without requiring the project to update to a new version of rules_fuzzing.

This commit introduces a list of runfiles (identified by workspace name and short_path) that should be replaced with the OSS-Fuzz provided files. This is achieved by replacing the actual runfile in the generated tar archive with a relative symlink pointing to the corresponding file with the same basename in the top-level $OUT directory.

This resolves 1. in https://github.com/bazelbuild/rules_fuzzing/pull/146#discussion_r632299433 in a generic way that can be adapted easily to cover other languages.

Depends on #149.