### PR TITLE
Various tweaks in engine launchers for regression mode.

### DIFF
--- a/fuzzing/engines/honggfuzz_launcher.sh
+++ b/fuzzing/engines/honggfuzz_launcher.sh
@@ -22,10 +22,12 @@ else
     command_line+=("--input=${FUZZER_OUTPUT_CORPUS_DIR}")
 fi
 if (( FUZZER_IS_REGRESSION )); then
-    # There is no regression mode in Honggfuzz, use minimization to a
-    # temporary output as the closest proxy.
-    command_line+=("--minimize")
+    # Dry-run-only mode - see https://github.com/google/honggfuzz/issues/296.
+    command_line+=("--mutations_per_run=0")
+    command_line+=("--verifier")
+    # Make the output more suitable for debugging.
     command_line+=("--verbose")
+    command_line+=("--keep_output")
 fi
 
 command_line+=("--crashdir=${FUZZER_ARTIFACTS_DIR}")

--- a/fuzzing/engines/jazzer_launcher.sh
+++ b/fuzzing/engines/jazzer_launcher.sh
@@ -29,6 +29,8 @@ if [[ "${FUZZER_TIMEOUT_SECS}" -gt 0 ]]; then
 fi
 if (( FUZZER_IS_REGRESSION )); then
     command_line+=("-runs=0")
+else
+    command_line+=("${FUZZER_OUTPUT_CORPUS_DIR}")
 fi
 
 # Jazzer flags.
@@ -36,7 +38,6 @@ command_line+=("--reproducer_path=${FUZZER_ARTIFACTS_DIR}")
 
 # Corpus sources.
 
-command_line+=("${FUZZER_OUTPUT_CORPUS_DIR}")
 if [[ -n "${FUZZER_SEED_CORPUS_DIR}" ]]; then
     command_line+=("${FUZZER_SEED_CORPUS_DIR}")
 fi

--- a/fuzzing/engines/libfuzzer_launcher.sh
+++ b/fuzzing/engines/libfuzzer_launcher.sh
@@ -29,11 +29,12 @@ if [[ "${FUZZER_TIMEOUT_SECS}" -gt 0 ]]; then
 fi
 if (( FUZZER_IS_REGRESSION )); then
     command_line+=("-runs=0")
+else
+    command_line+=("${FUZZER_OUTPUT_CORPUS_DIR}")
 fi
 
 # Corpus sources.
 
-command_line+=("${FUZZER_OUTPUT_CORPUS_DIR}")
 if [[ -n "${FUZZER_SEED_CORPUS_DIR}" ]]; then
     command_line+=("${FUZZER_SEED_CORPUS_DIR}")
 fi


### PR DESCRIPTION
For LibFuzzer, do not read the output corpus in regression mode.

For Honggfuzz, use dry-run-only mode instead of minimize mode for more expected behavior, and enable outputs from the target for easier debugging.