### PR TITLE
Add OSS-Fuzz support to java_fuzz_test

### DIFF
--- a/.github/workflows/oss_fuzz.yml
+++ b/.github/workflows/oss_fuzz.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   fuzzing:
-    name: Brief run of OSS-Fuzz fuzzing
+    name: Brief run of OSS-Fuzz fuzzing (C++)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,6 +35,32 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'bazel-rules-fuzzing-test'
+        fuzz-seconds: 60
+        dry-run: false
+    - name: Upload crashes
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts
+
+  fuzzing-java:
+    name: Brief run of OSS-Fuzz fuzzing (Java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Build fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'bazel-rules-fuzzing-test-java'
+        language: jvm
+        dry-run: false
+    - name: Run fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'bazel-rules-fuzzing-test-java'
+        language: jvm
         fuzz-seconds: 60
         dry-run: false
     - name: Upload crashes

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Our libFuzzer test will start running and immediately discover the buffer overfl
 
 ```
 INFO: Seed: 2957541205
-INFO: Loaded 1 modules   (8 inline 8-bit counters): 8 [0x5aab10, 0x5aab18), 
-INFO: Loaded 1 PC tables (8 PCs): 8 [0x5aab18,0x5aab98), 
+INFO: Loaded 1 modules   (8 inline 8-bit counters): 8 [0x5aab10, 0x5aab18),
+INFO: Loaded 1 PC tables (8 PCs): 8 [0x5aab18,0x5aab98),
 INFO:      755 files found in /tmp/fuzzing/corpus
 INFO:        0 files found in fuzz_test_corpus
 INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 35982 bytes
@@ -214,7 +214,7 @@ INFO: seed corpus: files: 16 min: 1b max: 19b total: 210b rss: 199Mb
 
 Once you wrote and tested the fuzz test, you should run it on continuous fuzzing infrastructure so it starts generating tests and finding new crashes in your code.
 
-The C++ fuzzing rules provide out-of-the-box support for [OSS-Fuzz](https://github.com/google/oss-fuzz), free continuous fuzzing infrastructure from Google for open source projects. Read its [Bazel project guide][bazel-oss-fuzz] for detailed instructions.
+The fuzzing rules provide out-of-the-box support for [OSS-Fuzz](https://github.com/google/oss-fuzz), free continuous fuzzing infrastructure from Google for open source projects. Read its [Bazel project guide][bazel-oss-fuzz] for detailed instructions.
 
 ## Where to go from here?
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ INFO: seed corpus: files: 16 min: 1b max: 19b total: 210b rss: 199Mb
 
 Once you wrote and tested the fuzz test, you should run it on continuous fuzzing infrastructure so it starts generating tests and finding new crashes in your code.
 
-The fuzzing rules provide out-of-the-box support for [OSS-Fuzz](https://github.com/google/oss-fuzz), free continuous fuzzing infrastructure from Google for open source projects. Read its [Bazel project guide][bazel-oss-fuzz] for detailed instructions.
+The C++ and Java fuzzing rules provide out-of-the-box support for [OSS-Fuzz](https://github.com/google/oss-fuzz), free continuous fuzzing infrastructure from Google for open source projects. Read its [Bazel project guide][bazel-oss-fuzz] for detailed instructions.
 
 ## Where to go from here?
 

--- a/docs/java-fuzzing-rules.md
+++ b/docs/java-fuzzing-rules.md
@@ -83,8 +83,7 @@ documentation for the set of targets generated.
 ## java_fuzz_test
 
 <pre>
-java_fuzz_test(<a href="#java_fuzz_test-name">name</a>, <a href="#java_fuzz_test-srcs">srcs</a>, <a href="#java_fuzz_test-target_class">target_class</a>, <a href="#java_fuzz_test-transitive_native_deps">transitive_native_deps</a>, <a href="#java_fuzz_test-corpus">corpus</a>, <a href="#java_fuzz_test-dicts">dicts</a>, <a href="#java_fuzz_test-engine">engine</a>, <a href="#java_fuzz_test-tags">tags</a>,
-               <a href="#java_fuzz_test-binary_kwargs">binary_kwargs</a>)
+java_fuzz_test(<a href="#java_fuzz_test-name">name</a>, <a href="#java_fuzz_test-srcs">srcs</a>, <a href="#java_fuzz_test-target_class">target_class</a>, <a href="#java_fuzz_test-corpus">corpus</a>, <a href="#java_fuzz_test-dicts">dicts</a>, <a href="#java_fuzz_test-engine">engine</a>, <a href="#java_fuzz_test-tags">tags</a>, <a href="#java_fuzz_test-binary_kwargs">binary_kwargs</a>)
 </pre>
 
 Defines a Java fuzz test and a few associated tools and metadata.
@@ -100,6 +99,11 @@ most relevant ones are:
   rarely.
 * `<name>_run`: An executable target used to launch the fuzz test using a
   simpler, engine-agnostic command line interface.
+* `<name>_oss_fuzz`: Generates a `<name>_oss_fuzz.tar` archive containing
+  the fuzz target executable and its associated resources (corpus,
+  dictionary, etc.) in a format suitable for unpacking in the $OUT/
+  directory of an OSS-Fuzz build. This target can be used inside the
+  `build.sh` script of an OSS-Fuzz project.
 
 
 **PARAMETERS**
@@ -110,7 +114,6 @@ most relevant ones are:
 | <a id="java_fuzz_test-name"></a>name |  A unique name for this target. Required.   |  none |
 | <a id="java_fuzz_test-srcs"></a>srcs |  A list of source files of the target.   |  <code>None</code> |
 | <a id="java_fuzz_test-target_class"></a>target_class |  The class that contains the static fuzzerTestOneInput   method. Defaults to the same class main_class would.   |  <code>None</code> |
-| <a id="java_fuzz_test-transitive_native_deps"></a>transitive_native_deps |  A list of all native libraries that the fuzz   target transitively depends on. The libraries are instrumented   automatically and do not need to be mentioned in deps. Listing the   libraries in this way is no longer required as of Bazel 5.   |  <code>None</code> |
 | <a id="java_fuzz_test-corpus"></a>corpus |  A list containing corpus files.   |  <code>None</code> |
 | <a id="java_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  <code>None</code> |
 | <a id="java_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  <code>"@rules_fuzzing//fuzzing:java_engine"</code> |

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -38,6 +38,9 @@ java_fuzz_test(
 java_fuzz_test(
     name = "JavaFuzzTest",
     srcs = ["com/example/JavaFuzzTest.java"],
+    tags = [
+        "no-oss-fuzz",
+    ],
 )
 
 java_fuzz_test(
@@ -46,7 +49,10 @@ java_fuzz_test(
     corpus = [
         ":corpus",
     ],
-    transitive_native_deps = [
+    tags = [
+        "no-oss-fuzz",
+    ],
+    deps = [
         ":native",
     ],
 )

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -57,6 +57,18 @@ java_fuzz_test(
     ],
 )
 
+java_fuzz_test(
+    name = "JavaNativeRunfileFuzzTest",
+    srcs = ["com/example/JavaNativeRunfileFuzzTest.java"],
+    data = [
+        "corpus_0.txt",
+    ],
+    deps = [
+        ":native_runfile",
+        "@bazel_tools//tools/java/runfiles",
+    ],
+)
+
 # A native library that interfaces with Java through the JNI.
 cc_binary(
     name = "native",
@@ -66,6 +78,22 @@ cc_binary(
     ],
     linkshared = True,
     deps = [
+        "@bazel_tools//tools/jdk:jni",
+    ],
+)
+
+cc_binary(
+    name = "native_runfile",
+    srcs = [
+        "com/example/JavaNativeRunfileFuzzTest.cpp",
+        "com/example/JavaNativeRunfileFuzzTest.h",
+    ],
+    data = [
+        "corpus_1.txt",
+    ],
+    linkshared = True,
+    deps = [
+        "@bazel_tools//tools/cpp/runfiles",
         "@bazel_tools//tools/jdk:jni",
     ],
 )

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -91,6 +91,8 @@ cc_binary(
     data = [
         "corpus_1.txt",
     ],
+    # Build as a shared library that can be loaded by a Java application at
+    # runtime via System.loadLibrary().
     linkshared = True,
     deps = [
         "@bazel_tools//tools/cpp/runfiles",

--- a/examples/java/com/example/JavaNativeRunfileFuzzTest.cpp
+++ b/examples/java/com/example/JavaNativeRunfileFuzzTest.cpp
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "JavaNativeRunfileFuzzTest.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "tools/cpp/runfiles/runfiles.h"
+
+JNIEXPORT void JNICALL
+Java_com_example_JavaNativeRunfileFuzzTest_loadCppRunfile(JNIEnv *env,
+                                                          jobject o) {
+  using ::bazel::tools::cpp::runfiles::Runfiles;
+  std::string error;
+  Runfiles *runfiles = Runfiles::Create("", &error);
+  if (runfiles == nullptr) {
+    std::cerr << error;
+    abort();
+  }
+  std::string path =
+      runfiles->Rlocation("rules_fuzzing/examples/java/corpus_1.txt");
+  if (path.empty()) abort();
+  std::ifstream in(path);
+  if (!in.good()) abort();
+}

--- a/examples/java/com/example/JavaNativeRunfileFuzzTest.h
+++ b/examples/java/com/example/JavaNativeRunfileFuzzTest.h
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+/* Header for class com_example_JavaNativeRunfileFuzzTest */
+
+#ifndef EXAMPLES_JAVA_COM_EXAMPLE_JAVANATIVERUNFILEFUZZTEST_H_
+#define EXAMPLES_JAVA_COM_EXAMPLE_JAVANATIVERUNFILEFUZZTEST_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_example_JavaNativeRunfileFuzzTest
+ * Method:    loadCppRunfile
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_com_example_JavaNativeRunfileFuzzTest_loadCppRunfile(JNIEnv *, jobject);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // EXAMPLES_JAVA_COM_EXAMPLE_JAVANATIVERUNFILEFUZZTEST_H_

--- a/examples/java/com/example/JavaNativeRunfileFuzzTest.java
+++ b/examples/java/com/example/JavaNativeRunfileFuzzTest.java
@@ -1,0 +1,47 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.google.devtools.build.runfiles.Runfiles;
+
+import java.io.IOException;
+import java.io.File;
+
+public class JavaNativeRunfileFuzzTest {
+
+    static {
+        System.loadLibrary("native_runfile");
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) throws IOException {
+        if (data.consumeBoolean()) {
+            loadJavaRunfile();
+        } else {
+            loadCppRunfile();
+        }
+    }
+
+    private static void loadJavaRunfile() throws IOException {
+        Runfiles runfiles = Runfiles.create();
+        String path = runfiles.rlocation("rules_fuzzing/examples/java/corpus_0.txt");
+        File runfile = new File(path);
+        if (!runfile.exists()) {
+            throw new IOException("Java runfile not found");
+        }
+    }
+
+    private static native void loadCppRunfile();
+}

--- a/fuzzing/private/BUILD
+++ b/fuzzing/private/BUILD
@@ -43,3 +43,18 @@ config_setting(
         "@rules_fuzzing//fuzzing:cc_engine_sanitizer": "asan",
     },
 )
+
+config_setting(
+    name = "use_oss_fuzz",
+    flag_values = {
+        "@rules_fuzzing//fuzzing:cc_engine": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
+        # This is required to make the setting an unambiguous specialization of
+        # the use_sanitizer_* settings.
+        "@rules_fuzzing//fuzzing:cc_engine_sanitizer": "none",
+    },
+)
+
+exports_files([
+    "local_jazzer_sanitizer_options.sh",
+    "oss_fuzz_jazzer_sanitizer_options.sh",
+])

--- a/fuzzing/private/java_utils.bzl
+++ b/fuzzing/private/java_utils.bzl
@@ -15,6 +15,7 @@
 """Utilities and helper rules for Java fuzz tests."""
 
 load("//fuzzing/private:binary.bzl", "fuzzing_binary_transition")
+load("//fuzzing/private:util.bzl", "runfile_path")
 
 # A Starlark reimplementation of a part of Bazel's JavaCommon#determinePrimaryClass.
 def determine_primary_class(srcs, name):
@@ -80,51 +81,65 @@ def _java_segment_index(path_segments):
 
     return root_index
 
-def _jazzer_fuzz_binary_script(ctx):
+def _jazzer_fuzz_binary_script(ctx, native_libs, driver):
     script = ctx.actions.declare_file(ctx.label.name)
 
-    script_template = """
-exec "{driver}" \
-    --agent_path="{agent}" \
-    --cp="{deploy_jar}" \
-    --jvm_args="-Djava.library.path={library_path}" \
+    # The script is split into two parts: The first is emitted as-is, the second
+    # is a template that is passed to format(). Without the split, curly braces
+    # in the first part would need to be escaped.
+    script_literal_part = """#!/bin/bash
+# LLVMFuzzerTestOneInput - OSS-Fuzz needs this string literal to appear
+# somewhere in the script so it is recognized as a fuzz target.
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Export the env variables required for subprocesses to find their runfiles.
+runfiles_export_envvars
+
+# Determine the path to load libjvm.so from, either relative to the location of
+# the java binary or to $JAVA_HOME, if set. On OSS-Fuzz, the path is provided in
+# JVM_LD_LIBRARY_PATH.
+JAVA_BIN=$(readlink -f "$(which java)")
+JAVA_HOME=${JAVA_HOME:-${JAVA_BIN%/bin/java}}
+# The location of libjvm.so relative to the JDK differs between JDK <= 8 and 9+.
+JVM_LD_LIBRARY_PATH=${JVM_LD_LIBRARY_PATH:-"$JAVA_HOME/lib/server:$JAVA_HOME/lib/amd64/server"}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$JVM_LD_LIBRARY_PATH
+"""
+
+    script_format_part = """
+source "$(rlocation {sanitizer_options})"
+exec "$(rlocation {driver})" \
+    --agent_path="$(rlocation {agent})" \
+    --cp="$(rlocation {deploy_jar})" \
+    --jvm_args="-Djava.library.path={native_dirs}" \
     "$@"
 """
 
-    # Perform feature detection for
-    # https://github.com/bazelbuild/bazel/commit/381a519dfc082d4c62096c4ce77ead1c2e0410d8.
-    target_info = ctx.attr.target[0][JavaInfo]
-    if "transitive_native_libraries" in dir(target_info):
-        # The current version of Bazel contains the commit, which means that
-        # the JavaInfo of the target includes information about all transitive
-        # native library dependencies.
-        native_libraries_list = target_info.transitive_native_libraries.to_list()
-        native_paths = [
-            lib.dynamic_library.short_path
-            for lib in native_libraries_list
-        ]
-    else:
-        # Fall back to the list of native library dependencies specified by the user.
-        native_files = [
-            native_dep[DefaultInfo].files
-            for native_dep in ctx.attr.transitive_native_deps
-        ]
-        native_paths = [
-            file.short_path
-            for file in depset(transitive = native_files).to_list()
-        ]
-    native_dirs = [path[:path.rfind("/")] for path in native_paths]
+    native_dirs = [
+        "$(dirname \"$(rlocation %s)\")" % runfile_path(ctx, lib)
+        for lib in native_libs
+    ]
 
-    script_content = script_template.format(
-        driver = ctx.executable.driver.short_path,
-        agent = ctx.file._agent.short_path,
-        deploy_jar = ctx.file.target_deploy_jar.short_path,
-        library_path = ":".join(native_dirs),
+    script_content = script_literal_part + script_format_part.format(
+        agent = runfile_path(ctx, ctx.file.agent),
+        deploy_jar = runfile_path(ctx, ctx.file.target_deploy_jar),
+        driver = runfile_path(ctx, driver),
+        native_dirs = ":".join(native_dirs),
+        sanitizer_options = runfile_path(ctx, ctx.file.sanitizer_options),
     )
     ctx.actions.write(script, script_content, is_executable = True)
     return script
 
-def _is_required_runfile(target, runtime_classpath, runfile):
+def _is_required_runfile(runfile, runtime_classpath = []):
     # The jars in the runtime classpath are all merged into the deploy jar and
     # thus don't need to be included in the runfiles for the fuzzer.
     if runfile in runtime_classpath:
@@ -143,19 +158,79 @@ def _filter_target_runfiles(ctx, target):
     return ctx.runfiles([
         runfile
         for runfile in all_runfiles.files.to_list()
-        if _is_required_runfile(target, runtime_classpath, runfile)
+        if _is_required_runfile(runfile, runtime_classpath)
     ])
 
+def _is_potential_native_dependency(file):
+    if file.extension not in ["dll", "dylib", "so"]:
+        return False
+    if not _is_required_runfile(file):
+        return False
+    return True
+
+def _native_library_files(ctx):
+    target_info = ctx.attr.target[0][DefaultInfo]
+    target_java_info = ctx.attr.target[0][JavaInfo]
+
+    # Perform feature detection for
+    # https://github.com/bazelbuild/bazel/commit/381a519dfc082d4c62096c4ce77ead1c2e0410d8.
+    if hasattr(target_java_info, "transitive_native_libraries"):
+        # The current version of Bazel contains the commit, which means that
+        # the JavaInfo of the target includes information about all transitive
+        # native library dependencies.
+        native_libraries_list = target_java_info.transitive_native_libraries.to_list()
+        return [lib.dynamic_library for lib in native_libraries_list]
+    else:
+        # If precise information about transitive native libraries is not
+        # available, fall back to an overapproximation that includes all
+        # runfiles with file extensions indicating a shared library.
+        runfiles_list = target_info.default_runfiles.files.to_list()
+        return [
+            runfile
+            for runfile in runfiles_list
+            if _is_potential_native_dependency(runfile)
+        ]
+
 def _jazzer_fuzz_binary_impl(ctx):
-    script = _jazzer_fuzz_binary_script(ctx)
+    native_libs = _native_library_files(ctx)
+
+    # Use a driver with a linked in sanitizer if the fuzz test has native
+    # dependencies.
+    if native_libs:
+        driver = ctx.executable.driver_with_native
+        driver_info = ctx.attr.driver_with_native[DefaultInfo]
+    else:
+        driver = ctx.executable.driver_java_only
+        driver_info = ctx.attr.driver_java_only[DefaultInfo]
+
+    # The DefaultInfo's default_runfiles of an executable file target do not
+    # contain the executable itself, which thus needs to be added explicitly.
+    driver_runfiles = driver_info.default_runfiles
+    driver_executable = driver_info.files_to_run.executable
+    driver_runfiles = driver_runfiles.merge(ctx.runfiles([driver_executable]))
 
     runfiles = ctx.runfiles()
-    runfiles = runfiles.merge(ctx.attr.driver[DefaultInfo].default_runfiles)
-    runfiles = runfiles.merge(ctx.runfiles([ctx.file._agent]))
-    runfiles = runfiles.merge(_filter_target_runfiles(ctx, ctx.attr.target[0]))
+    runfiles = runfiles.merge(driver_runfiles)
+
+    # Used by the wrapper script created in _jazzer_fuzz_binary_script.
+    runfiles = runfiles.merge(ctx.attr._bash_runfiles_library[DefaultInfo].default_runfiles)
+
+    # While the Jazzer agent is already included in the runfiles of
+    # @jazzer//driver:jazzer_driver, it has to be added here explicitly for the
+    # case where both are provided by OSS-Fuzz.
+    runfiles = runfiles.merge(ctx.runfiles([ctx.file.agent]))
+
+    # The Java fuzz target packaged as a jar including all Java dependencies.
+    # This does not include e.g. data runfiles and shared libraries.
     runfiles = runfiles.merge(ctx.runfiles([ctx.file.target_deploy_jar]))
-    for native_dep in ctx.attr.transitive_native_deps:
-        runfiles = runfiles.merge(native_dep[DefaultInfo].default_runfiles)
+
+    # The full runfiles of the Java fuzz target, but with the files of the local
+    # JDK and all jar files excluded.
+    runfiles = runfiles.merge(_filter_target_runfiles(ctx, ctx.attr.target[0]))
+
+    runfiles = runfiles.merge(ctx.runfiles([ctx.file.sanitizer_options]))
+
+    script = _jazzer_fuzz_binary_script(ctx, native_libs, driver)
     return [DefaultInfo(executable = script, runfiles = runfiles)]
 
 jazzer_fuzz_binary = rule(
@@ -164,26 +239,36 @@ jazzer_fuzz_binary = rule(
 Rule that creates a binary that invokes Jazzer on the specified target.
 """,
     attrs = {
-        "_agent": attr.label(
-            default = Label("@jazzer//agent:jazzer_agent_deploy.jar"),
+        "agent": attr.label(
             doc = "The Jazzer agent used to instrument the target.",
             allow_single_file = [".jar"],
         ),
-        "driver": attr.label(
-            default = Label("@jazzer//driver:jazzer_driver"),
-            doc = "The Jazzer driver binary used to fuzz the target.",
+        "_bash_runfiles_library": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+        "driver_java_only": attr.label(
+            doc = "The Jazzer driver binary used to fuzz a Java-only target.",
+            allow_single_file = True,
             executable = True,
             # Build in target configuration rather than host because the driver
             # uses transitions to set the correct C++ standard for its
             # dependencies.
             cfg = "target",
         ),
-        "transitive_native_deps": attr.label_list(
-            doc = "The native libraries the fuzz target transitively depends " +
-                  "on. The libraries are automatically instrumented for " +
-                  "fuzzing.",
-            providers = [CcInfo],
-            cfg = fuzzing_binary_transition,
+        "driver_with_native": attr.label(
+            doc = "The Jazzer driver binary used to fuzz a Java target with " +
+                  "native dependencies.",
+            allow_single_file = True,
+            executable = True,
+            # Build in target configuration rather than host because the driver
+            # uses transitions to set the correct C++ standard for its
+            # dependencies.
+            cfg = "target",
+        ),
+        "sanitizer_options": attr.label(
+            doc = "A shell script that can export environment variables with " +
+                  "sanitizer options.",
+            allow_single_file = [".sh"],
         ),
         "target": attr.label(
             doc = "The fuzz target.",

--- a/fuzzing/private/java_utils.bzl
+++ b/fuzzing/private/java_utils.bzl
@@ -91,6 +91,8 @@ def _jazzer_fuzz_binary_script(ctx, native_libs, driver):
 # LLVMFuzzerTestOneInput - OSS-Fuzz needs this string literal to appear
 # somewhere in the script so it is recognized as a fuzz target.
 
+# Bazel-provided code snippet that should be copy-pasted as is at use sites.
+# Taken from @bazel_tools//tools/bash/runfiles.
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
 set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash

--- a/fuzzing/private/local_jazzer_sanitizer_options.sh
+++ b/fuzzing/private/local_jazzer_sanitizer_options.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/fuzzing/private/oss_fuzz_jazzer_sanitizer_options.sh
+++ b/fuzzing/private/oss_fuzz_jazzer_sanitizer_options.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# llvm-symbolizer is a sibling of the wrapper script that sources the current
+# script.
+declare -r this_dir=$(dirname "${BASH_SOURCE}")
+COMMON_SANITIZER_OPTIONS=symbolize=1:external_symbolizer_path=$this_dir/llvm-symbolizer:detect_leaks=0:handle_segv=1
+
+export ASAN_OPTIONS=${ASAN_OPTIONS:+${ASAN_OPTIONS}:}$COMMON_SANITIZER_OPTIONS:allow_user_segv_handler=1
+export UBSAN_OPTIONS=${UBSAN_OPTIONS:+${UBSAN_OPTIONS}:}$COMMON_SANITIZER_OPTIONS

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -72,7 +72,7 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
         maybe(
             http_archive,
             name = "jazzer",
-            sha256 = "797d29ceae19ce36a95f5fbfd995bca2815256c8d5f7a705e84897336a4fea61",
-            strip_prefix = "jazzer-f1c4bb507733710bbf292e474e173fcd0d6e8ff5",
-            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/f1c4bb507733710bbf292e474e173fcd0d6e8ff5.zip",
+            sha256 = "cf41aca8fbfb6904951e88bb8df1d0fc743396577bcb39c4f5a2408329061e37",
+            strip_prefix = "jazzer-316da57a8688470fcfd5521673239b5fa66512ba",
+            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/316da57a8688470fcfd5521673239b5fa66512ba.zip",
         )


### PR DESCRIPTION
This commit makes the <basename>_oss_fuzz targets of java_fuzz_test
instances work in OSS-Fuzz, based on the runfiles support and the
handling of OSS-Fuzz provided binaries introduced in previous PRs.

The following parts of the commit are notable:
* The Jazzer update results in a simplified runfiles structure of the
  driver, which prevents runfile paths clashes.
* Since .options files are discouraged, target-dependant shell scripts
  are used to set the required options for sanitizers.
* The transitive_native_deps attribute of java_fuzz_test is removed in
  favor of an overapproximation of the Java library path, which makes
  the java_fuzz_test easier to use with Bazel 4.

Replaces #146.