### PR TITLE
Use correct `cc_engine_instrumentation` in `jazzer` config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,14 +59,14 @@ build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
 # Jazzer without sanitizer (Java only)
 build:jazzer --//fuzzing:java_engine=//fuzzing/engines:jazzer
-build:jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
+build:jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 # Workaround for https://github.com/bazelbuild/bazel/issues/11128
 build:jazzer --//fuzzing:cc_engine_sanitizer=none
 
 # Jazzer + ASAN
 build:asan-jazzer --//fuzzing:java_engine=//fuzzing/engines:jazzer
-build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 # Workaround for https://github.com/bazelbuild/bazel/issues/11128
 build:asan-jazzer --//fuzzing:cc_engine_sanitizer=asan

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -72,7 +72,7 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
         maybe(
             http_archive,
             name = "jazzer",
-            sha256 = "cf41aca8fbfb6904951e88bb8df1d0fc743396577bcb39c4f5a2408329061e37",
-            strip_prefix = "jazzer-316da57a8688470fcfd5521673239b5fa66512ba",
-            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/316da57a8688470fcfd5521673239b5fa66512ba.zip",
+            sha256 = "c8d187663365f625bb00d6b531ede17898d87bbaed59de16a85590117cff0fa4",
+            strip_prefix = "jazzer-1b11bd6515a65f02a1cbe5aaa183180faa92a55b",
+            url = "https://github.com/CodeIntelligenceTesting/jazzer/archive/1b11bd6515a65f02a1cbe5aaa183180faa92a55b.zip",
         )


### PR DESCRIPTION
While the `cc_engine_instrumentation` settings `libfuzzer` and `jazzer` lead to the same instrumentation, this may not remain so indefinitely. Thus the `jazzer` and `asan-jazzer` config in `.bazelrc` should use the `jazzer` value for the setting.

Also, even when not using a sanitizer via the `jazzer` config, native library dependencies should be instrumented for fuzzing.

This requires updating Jazzer to the latest version as previous versions did not correctly export certain sanitizer symbols.
