### PR TITLE
Disable leak instrumentation for Jazzer

### DIFF
--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -33,7 +33,7 @@ load(
 instrum_configs = {
     "none": instrum_opts.make(),
     "libfuzzer": instrum_defaults.libfuzzer,
-    "jazzer": instrum_defaults.libfuzzer,
+    "jazzer": instrum_defaults.jazzer,
     "honggfuzz": instrum_defaults.honggfuzz,
     "oss-fuzz": oss_fuzz_opts,
 }

--- a/fuzzing/private/instrum_opts.bzl
+++ b/fuzzing/private/instrum_opts.bzl
@@ -80,6 +80,15 @@ instrum_defaults = struct(
     libfuzzer = _make_opts(
         copts = ["-fsanitize=fuzzer-no-link"],
     ),
+    # Jazzer is based on libFuzzer and hence generally requires the same
+    # instrumentation for native code. Since it does not support
+    # LeakSanitizer, the corresponding instrumentation can be disabled.
+    jazzer = _make_opts(
+        copts = [
+            "-fsanitize=fuzzer-no-link",
+            "-fno-sanitize=leak",
+        ],
+    ),
     # Reflects the set of options at
     # https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c
     honggfuzz = _make_opts(


### PR DESCRIPTION
Jazzer is based on libFuzzer and hence generally requires the same
instrumentation for native code. Since it does not support
LeakSanitizer, the corresponding instrumentation can be disabled to
save some (potentially negligible) runtime cost.