### PR TITLE
Set `RUNFILES_DIR` in launcher

### DIFF
--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -23,6 +23,7 @@ def _fuzzing_launcher_script(ctx):
     script_template = """
 {environment}
 echo "Launching {binary_path} as a {engine_name} fuzz test..."
+RUNFILES_DIR="$0.runfiles" \
 exec "{launcher}" \
     --engine_launcher="{engine_launcher}" \
     --binary_path="{binary_path}" \


### PR DESCRIPTION
While `cc_fuzz_test` and `java_fuzz_test` do find their runfiles when
executed, this is not strictly guaranteed without an explicitly set
`RUNFILES_DIR` variable.