### PR TITLE
Reorganize and update the Java documentation in the README file in a …

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzz
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 ```
 
-Examples for other combinations of fuzzing engine and sanitizer can be found in the project's [`.bazelrc`](/.bazelrc).
+Examples for other combinations of fuzzing engine and sanitizer can be found in the [User Guide](/docs/guide.md#configuring-the-bazelrc-file).
 
 ### Defining a C++ fuzz test
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ To use Jazzer, it is convienient to also define a `.bazelrc` configuration, simi
 
 ```
 # Force the use of Clang for all builds (needed to build Jazzer).
-build --action_env=CC=clang-10
-build --action_env=CXX=clang++-10
+build --action_env=CC=clang
+build --action_env=CXX=clang++
 
 # Define --config=jazzer for Jazzer without sanitizer (Java only).
 build:jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The crash is saved under `/tmp/fuzzing/artifacts` and can be further inspected.
 You can write `java_fuzz_tests` through the [Jazzer][jazzer-doc] fuzzing engine. You will need to enable it in your WORKSPACE `rules_fuzzing_dependencies` call:
 
 ```python
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
 rules_fuzzing_dependencies(jazzer = True)
 
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ This repository contains [Bazel](https://bazel.build/) [Starlark extensions](htt
 
 [Fuzzing](https://en.wikipedia.org/wiki/Fuzzing) is an effective technique for uncovering security and stability bugs in software. Fuzzing works by invoking the code under test (e.g., a library API) with automatically generated data, and observing its execution to discover incorrect behavior, such as memory corruption or failed invariants. Read more [here](https://github.com/google/fuzzing) about fuzzing, additional examples, best practices, and other resources.
 
+The rule library currently provides support for C++ and Java fuzz tests. Support for additional languages may be added in the future.
+
 ## Features at a glance
 
 * Multiple fuzzing engines out of the box:
   * [libFuzzer][libfuzzer-doc]
   * [Honggfuzz][honggfuzz-doc]
-  * [Jazzer][jazzer-doc]
+  * Java fuzzing through [Jazzer][jazzer-doc]
 * Multiple sanitizer configurations:
   * [Address Sanitizer][asan-doc]
   * [Memory Sanitizer][msan-doc]
@@ -22,8 +24,6 @@ This repository contains [Bazel](https://bazel.build/) [Starlark extensions](htt
 * Customization options:
   * Defining additional fuzzing engines
   * Customizing the behavior of the fuzz test rule.
-
-The rule library currently provides support for C++ and Java fuzz tests. Support for additional languages may be added in the future.
 
 Contributions are welcome! Please read the [contribution guidelines](/docs/contributing.md).
 

--- a/README.md
+++ b/README.md
@@ -169,12 +169,10 @@ To use Jazzer, it is convienient to also define a `.bazelrc` configuration, simi
 build:jazzer --@rules_fuzzing//fuzzing:java_engine=//fuzzing/engines:jazzer
 build:jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
-build:jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
 # Define --config=asan-jazzer for Jazzer + ASAN.
 build:asan-jazzer --@rules_fuzzing//fuzzing:java_engine=//fuzzing/engines:jazzer
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
-build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ jazzer_init()
 To use Jazzer, it is convienient to also define a `.bazelrc` configuration, similar to the C++ libFuzzer one above:
 
 ```
-# Force the use of Clang for all builds.
+# Force the use of Clang for all builds (needed to build Jazzer).
 build --action_env=CC=clang-10
 build --action_env=CXX=clang++-10
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ load("@jazzer//:init.bzl", "jazzer_init")
 jazzer_init()
 ```
 
-To use Jazzer, it is convienient to also define a `bazel.rc` configuration, similar to the C++ libFuzzer one above:
+To use Jazzer, it is convienient to also define a `.bazelrc` configuration, similar to the C++ libFuzzer one above:
 
 ```
 # Define --config=jazzer for Jazzer without sanitizer (Java only).

--- a/README.md
+++ b/README.md
@@ -165,20 +165,24 @@ jazzer_init()
 To use Jazzer, it is convienient to also define a `.bazelrc` configuration, similar to the C++ libFuzzer one above:
 
 ```
+# Force the use of Clang for all builds.
+build --action_env=CC=clang-10
+build --action_env=CXX=clang++-10
+
 # Define --config=jazzer for Jazzer without sanitizer (Java only).
-build:jazzer --@rules_fuzzing//fuzzing:java_engine=//fuzzing/engines:jazzer
+build:jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer
 build:jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
 # Define --config=asan-jazzer for Jazzer + ASAN.
-build:asan-jazzer --@rules_fuzzing//fuzzing:java_engine=//fuzzing/engines:jazzer
+build:asan-jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 ```
 
 A Java fuzz test is specified using a [`java_fuzz_test` rule](/docs/java-fuzzing-rules.md#java_fuzz_test). In the most basic form, a Java fuzz test consists of a single `.java` file with a class that defines a function `public static fuzzerTestOneInput(byte[] input)`.
 
-The Java equivalent of the C++ fuzz test above would look as follows:
+Create the `com/example/JavaFuzzTest.java` file in your workspace root, as follows:
 
 ```java
 package com.example;
@@ -194,14 +198,14 @@ public class JavaFuzzTest {
 }
 ```
 
-The corresponding build target looks very much like a regular `java_binary`:
+You should now define the corresponding target in the `BUILD` file, which looks very much like a regular `java_binary`:
 
 ```python
 load("@rules_fuzzing//fuzzing:java_defs.bzl", "java_fuzz_test")
 
 java_fuzz_test(
     name = "JavaFuzzTest",
-    srcs = ["JavaFuzzTest.java"],
+    srcs = ["com/example/JavaFuzzTest.java"],
     # target_class is not needed if using the Maven directory layout.
     target_class = "com.example.JavaFuzzTest",
 )

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The crash is saved under `/tmp/fuzzing/artifacts` and can be further inspected.
 
 ### Java fuzzing
 
-You can write `java_fuzz_tests` through the [Jazzer][jazzer-doc] fuzzing engine. You will need to enable it in your WORKSPACE `rules_fuzzing_dependencies` call:
+You can write `java_fuzz_test`s through the [Jazzer][jazzer-doc] fuzzing engine. You will need to enable it in your WORKSPACE `rules_fuzzing_dependencies` call:
 
 ```python
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")

--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ load("@jazzer//:init.bzl", "jazzer_init")
 jazzer_init()
 ```
 
-To use Jazzer, it is convienient to also define a `.bazelrc` configuration, similar to the C++ libFuzzer one above:
+To use Jazzer, it is convenient to also define a `.bazelrc` configuration, similar to the C++ libFuzzer one above:
 
 ```
-# Force the use of Clang for all builds (needed to build Jazzer).
+# Force the use of Clang for all builds (Jazzer requires at least Clang 9).
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
@@ -182,7 +182,7 @@ build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
 A Java fuzz test is specified using a [`java_fuzz_test` rule](/docs/java-fuzzing-rules.md#java_fuzz_test). In the most basic form, a Java fuzz test consists of a single `.java` file with a class that defines a function `public static fuzzerTestOneInput(byte[] input)`.
 
-Create the `com/example/JavaFuzzTest.java` file in your workspace root, as follows:
+Create the `src/com/example/JavaFuzzTest.java` file in your workspace root, as follows:
 
 ```java
 package com.example;
@@ -205,9 +205,9 @@ load("@rules_fuzzing//fuzzing:java_defs.bzl", "java_fuzz_test")
 
 java_fuzz_test(
     name = "JavaFuzzTest",
-    srcs = ["com/example/JavaFuzzTest.java"],
+    srcs = ["src/com/example/JavaFuzzTest.java"],
     # target_class is not needed if using the Maven directory layout.
-    target_class = "com.example.JavaFuzzTest",
+    # target_class = "com.example.JavaFuzzTest",
 )
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -161,21 +161,50 @@ $ bazel test \
     //examples:re2_fuzz_test
 ```
 
-This command is clearly too verbose to be used manually, so we recommend combining these options as a `--config` setting in your project's [`.bazelrc` file][bazelrc-docs]. For the example above, we can define an `asan-libfuzzer` config setting as follows:
-
-```
-build:asan-libfuzzer --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
-```
-
-To run your fuzz test, now you can simply invoke:
+This command is clearly too verbose to be used manually, so we recommend combining these options as a `--config` setting in your project's [`.bazelrc` file][bazelrc-docs]. For example, the command above can be replaced with:
 
 ```sh
 $ bazel test --config=asan-libfuzzer //examples:re2_fuzz_test
 ```
 
-You can add to your `.bazelrc` file as many configurations as you need. Feel free to use the [`.bazelrc` file of this repository](/.bazelrc) as a starting point.
+For convenience, we define below the most common configurations that you can pick and choose for your own `.bazelrc` file:
+
+```
+# --config=asan-libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+# --config=msan-libfuzzer
+build:msan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:msan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:msan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=msan
+
+# --config=asan-honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+# --config=msan-honggfuzz
+build:msan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
+build:msan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+build:msan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=msan
+
+# --config=asan-replay
+build:asan-replay --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:replay
+build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
+build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+# --config=jazzer (Jazzer without sanitizer - Java only)
+build:jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer
+build:jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
+build:jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+
+# --config=asan-jazzer
+build:asan-jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer
+build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
+build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+```
 
 ## Advanced topics
 


### PR DESCRIPTION
…single section. This should make it easier for readers to find all the Java-specific information.