### PR TITLE
Add coverage support for fuzzing_regression_test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,3 +70,15 @@ build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=jazzer
 build:asan-jazzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 # Workaround for https://github.com/bazelbuild/bazel/issues/11128
 build:asan-jazzer --//fuzzing:cc_engine_sanitizer=asan
+
+# Coverage with Replay (C/C++ only)
+coverage --//fuzzing:cc_engine=//fuzzing/engines:replay
+coverage --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
+coverage --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+coverage --instrument_test_targets
+coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+coverage --action_env=GCOV=llvm-profdata-10
+coverage --action_env=BAZEL_LLVM_COV=llvm-cov-10
+coverage --combined_report=lcov
+coverage --experimental_use_llvm_covmap
+coverage --experimental_generate_llvm_lcov

--- a/.github/workflows/bazel_test.yml
+++ b/.github/workflows/bazel_test.yml
@@ -81,6 +81,28 @@ jobs:
           bazel test --verbose_failures --test_output=all \
               --build_tag_filters=fuzz-test --config=${{ matrix.config }} \
               //examples:all
+  coverage:
+    name: Coverage gathering (C++)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        target: ["//examples:empty_fuzz_test", "//examples:re2_fuzz_test"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -yq \
+            clang-10 \
+            libunwind-dev \
+            libblocksruntime-dev
+      - name: Gather coverage
+        run: |
+          bazel coverage ${{ matrix.target }}
+      - name: Check coverage gathered is non-empty
+        run: |
+          [[ -s bazel-out/_coverage/_coverage_report.dat ]]
   fuzzer_run_tests_java:
     name: Brief fuzz test runs (Java)
     runs-on: ubuntu-latest

--- a/fuzzing/private/binary.bzl
+++ b/fuzzing/private/binary.bzl
@@ -131,6 +131,10 @@ def _fuzzing_binary_impl(ctx):
             engine_info = ctx.attr.engine[FuzzingEngineInfo],
             options_file = ctx.file.options,
         ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["binary"],
+        ),
     ]
 
 _common_fuzzing_binary_attrs = {

--- a/fuzzing/private/regression.bzl
+++ b/fuzzing/private/regression.bzl
@@ -46,7 +46,14 @@ exec '{engine_launcher}'
     runfiles = ctx.runfiles()
     runfiles = runfiles.merge(ctx.attr.binary[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(binary_info.engine_info.launcher_runfiles)
-    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+    return [
+        DefaultInfo(executable = script, runfiles = runfiles),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["binary"],
+        ),
+    ]
 
 fuzzing_regression_test = rule(
     implementation = _fuzzing_regression_test_impl,
@@ -60,6 +67,16 @@ Executes a fuzz test on its seed corpus.
             providers = [FuzzingBinaryInfo],
             cfg = "target",
             mandatory = True,
+        ),
+        "_lcov_merger": attr.label(
+            default = "@bazel_tools//tools/test:lcov_merger",
+            executable = True,
+            cfg = "host",
+        ),
+        "_collect_cc_coverage": attr.label(
+            default = "@bazel_tools//tools/test:collect_cc_coverage",
+            executable = True,
+            cfg = "host",
         ),
     },
     test = True,


### PR DESCRIPTION
Adds support for `bazel coverage` to gather coverage on fuzz targets replayed on the corpus.