### PR TITLE
Update abseil-cpp

### DIFF
--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -31,6 +31,15 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
 
     maybe(
         http_archive,
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+        ],
+        sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
+    )
+    maybe(
+        http_archive,
         name = "rules_python",
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
         sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
@@ -47,9 +56,9 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
     maybe(
         http_archive,
         name = "com_google_absl",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/4611a601a7ce8d5aad169417092e3d5027aa8403.zip"],
-        strip_prefix = "abseil-cpp-4611a601a7ce8d5aad169417092e3d5027aa8403",
-        sha256 = "f4f2d3d01c3cc99eebc9f370ea626c43a54b386913aef393bf8201b2c42a9e2f",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/f2dbd918d8d08529800eb72f23bd2829f92104a4.zip"],
+        strip_prefix = "abseil-cpp-f2dbd918d8d08529800eb72f23bd2829f92104a4",
+        sha256 = "5e1cbf25bf501f8e37866000a6052d02dbdd7b19a5b592251c59a4c9aa5c71ae",
     )
 
     if oss_fuzz:


### PR DESCRIPTION
abseil-cpp now depends on the Bazel platforms repository.

This update fixes the following compiler warnings with clang-13:

```
INFO: From Compiling absl/strings/internal/str_format/float_conversion.cc:
In file included from external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:28:
external/com_google_absl/absl/functional/function_ref.h:124:16: warning: definition of implicit copy constructor for 'FunctionRef<void (absl::Span<unsigned int>)>' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  FunctionRef& operator=(const FunctionRef& rhs) = delete;
               ^
external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:75:39: note: in implicit copy constructor for 'absl::FunctionRef<void (absl::Span<unsigned int>)>' first required here
        return RunWithCapacityImpl<1>(f);
                                      ^
In file included from external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:28:
external/com_google_absl/absl/functional/function_ref.h:124:16: warning: definition of implicit copy constructor for 'FunctionRef<void (absl::str_format_internal::(anonymous namespace)::BinaryToDecimal)>' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  FunctionRef& operator=(const FunctionRef& rhs) = delete;
               ^
external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:143:10: note: in implicit copy constructor for 'absl::FunctionRef<void (absl::str_format_internal::(anonymous namespace)::BinaryToDecimal)>' first required here
        [=](absl::Span<uint32_t> input) { f(BinaryToDecimal(input, v, exp)); });
         ^
In file included from external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:28:
external/com_google_absl/absl/functional/function_ref.h:124:16: warning: definition of implicit copy constructor for 'FunctionRef<void (absl::str_format_internal::(anonymous namespace)::FractionalDigitGenerator)>' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  FunctionRef& operator=(const FunctionRef& rhs) = delete;
               ^
external/com_google_absl/absl/strings/internal/str_format/float_conversion.cc:249:34: note: in implicit copy constructor for 'absl::FunctionRef<void (absl::str_format_internal::(anonymous namespace)::FractionalDigitGenerator)>' first required here
                                [=](absl::Span<uint32_t> input) {
                                 ^
3 warnings generated.
```