### PR TITLE
Instrument native libraries in deploy JARs

### DIFF
--- a/fuzzing/private/java_utils.bzl
+++ b/fuzzing/private/java_utils.bzl
@@ -282,6 +282,7 @@ Rule that creates a binary that invokes Jazzer on the specified target.
             doc = "The deploy jar of the fuzz target.",
             allow_single_file = [".jar"],
             mandatory = True,
+            cfg = fuzzing_binary_transition,
         ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",


### PR DESCRIPTION
Many Java projects using native libraries add them as resources rather
than relying on Bazel to add them to the native library path. This
change ensure that these libraries are correctly instrumented for
fuzzing.