### PR TITLE
Update rules_python to 0.6.0

### DIFF
--- a/fuzzing/init.bzl
+++ b/fuzzing/init.bzl
@@ -15,11 +15,9 @@
 """Dependency initialization utilities."""
 
 load("@rules_python//python:pip.bzl", "pip_install")
-load("@rules_python//python:repositories.bzl", "py_repositories")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 def rules_fuzzing_init():
-    py_repositories()
     pip_install(
         name = "fuzzing_py_deps",
         extra_pip_args = ["--require-hashes"],

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -41,8 +41,9 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = False
     maybe(
         http_archive,
         name = "rules_python",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
-        sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+        sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
+        strip_prefix = "rules_python-0.6.0",
+        url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
     )
     maybe(
         http_archive,


### PR DESCRIPTION
This allows us to get rid of the py_repositories() call in init.bzl.
This call is no longer needed with newer versions of rules_python and produces warnings.

Fixes #198