### PR TITLE
Fix bazel_lint job

### DIFF
--- a/.github/workflows/bazel_lint.yml
+++ b/.github/workflows/bazel_lint.yml
@@ -35,6 +35,6 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1' # The Go version to download (if necessary) and use.
-    - run: go get github.com/bazelbuild/buildtools/buildifier
+    - run: go install github.com/bazelbuild/buildtools/buildifier@latest
     - run: buildifier -lint=warn -mode=check $(find . -type f \( -name BUILD.bazel -or -name BUILD -or -name *.bzl \))
 

--- a/fuzzing/private/binary.bzl
+++ b/fuzzing/private/binary.bzl
@@ -45,7 +45,7 @@ Provider for storing information about a fuzz test binary.
     },
 )
 
-def _fuzzing_binary_transition_impl(settings, attr):
+def _fuzzing_binary_transition_impl(settings, _attr):
     opts = instrum_opts.make(
         copts = settings["//command_line_option:copt"],
         conlyopts = settings["//command_line_option:conlyopt"],

--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -66,7 +66,7 @@ Rule for creating a script to run the fuzzing test.
             default = Label("//fuzzing/tools:launcher"),
             doc = "The launcher script to start the fuzzing test.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "binary": attr.label(
             executable = True,
@@ -112,7 +112,7 @@ specified in the srcs attribute.
             default = Label("//fuzzing/tools:make_corpus_dir"),
             doc = "The tool script to copy and rename the corpus.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "srcs": attr.label_list(
             doc = "The corpus files for the fuzzing test.",
@@ -151,7 +151,7 @@ Rule to validate the fuzzing dictionaries and output a merged dictionary.
             default = Label("//fuzzing/tools:validate_dict"),
             doc = "The tool script to validate and merge the dictionaries.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "dicts": attr.label_list(
             doc = "The fuzzing dictionaries.",


### PR DESCRIPTION
go get is no longer a supported way to install binaries.