### PR TITLE
Use Bazel's default `PATH` when running Python actions

### DIFF
--- a/.github/workflows/bazel_test.yml
+++ b/.github/workflows/bazel_test.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   unit_tests:
     name: All unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -51,7 +51,7 @@ jobs:
           bazel test --test_tag_filters=-fuzz-test --build_tests_only --config=asan //...
   fuzzer_run_tests:
     name: Brief fuzz test runs (C++)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -75,7 +75,7 @@ jobs:
           bazel run ${{ matrix.target }} --config=${{ matrix.config }} -- --clean --timeout_secs=5
   regression_tests:
     name: Regression tests (C++)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -96,7 +96,7 @@ jobs:
               //examples:all
   fuzzer_run_tests_java:
     name: Brief fuzz test runs (Java)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -112,7 +112,7 @@ jobs:
           bazel run ${{ matrix.target }} --config=${{ matrix.config }} -- --clean --timeout_secs=5
   regression_tests_java:
     name: Regression tests (Java)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -129,7 +129,7 @@ jobs:
               //examples/java/...
   regression_tests_gcc:
     name: Regression tests (GCC)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -94,6 +94,9 @@ def _fuzzing_corpus_impl(ctx):
         outputs = [corpus_dir],
         arguments = [cp_args, corpus_list_file_args],
         executable = ctx.executable._corpus_tool,
+        # Use the default rather than an empty environment so that PATH is
+        # set and python can be found.
+        use_default_shell_env = True,
     )
 
     return [DefaultInfo(
@@ -132,6 +135,9 @@ def _fuzzing_dictionary_impl(ctx):
         outputs = [output_dict],
         arguments = [args],
         executable = ctx.executable._validation_tool,
+        # Use the default rather than an empty environment so that PATH is
+        # set and python can be found.
+        use_default_shell_env = True,
     )
 
     runfiles = ctx.runfiles(files = [output_dict])


### PR DESCRIPTION
Without `use_default_shell_env`, `PATH` was not set for Python actions, which resulted in `python` (or `python3`) not being found.