### PR TITLE
Add `asan-ubsan` instrumentation option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,6 +46,11 @@ build:ubsan-libfuzzer --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
 build:ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
 build:ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=ubsan
 
+# LibFuzzer + ASAN + UBSAN
+build:asan-ubsan-libfuzzer --//fuzzing:cc_engine=//fuzzing/engines:libfuzzer
+build:asan-ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan-ubsan
+
 # Honggfuzz + ASAN
 build:asan-honggfuzz --//fuzzing:cc_engine=//fuzzing/engines:honggfuzz
 build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
@@ -65,6 +70,11 @@ build:ubsan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=ubsan
 build:asan-replay --//fuzzing:cc_engine=//fuzzing/engines:replay
 build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
 build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+# Replay + ASAN + UBSAN
+build:asan-ubsan-replay --//fuzzing:cc_engine=//fuzzing/engines:replay
+build:asan-ubsan-replay --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
+build:asan-ubsan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan-ubsan
 
 build:oss-fuzz --//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
 build:oss-fuzz --//fuzzing:java_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_java_engine

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -186,6 +186,11 @@ build:ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzin
 build:ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
 build:ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=ubsan
 
+# --config=asan-ubsan-libfuzzer
+build:asan-ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:asan-ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-ubsan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan-ubsan
+
 # --config=asan-honggfuzz
 build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
 build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
@@ -205,6 +210,11 @@ build:ubsan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=ubsan
 build:asan-replay --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:replay
 build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
 build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
+
+# --config=asan-ubsan-replay
+build:asan-ubsan-replay --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:replay
+build:asan-ubsan-replay --@rules_fuzzing//fuzzing:cc_engine_instrumentation=none
+build:asan-ubsan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan-ubsan
 
 # --config=jazzer (Jazzer without sanitizer - Java only)
 build:jazzer --@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing//fuzzing/engines:jazzer

--- a/fuzzing/BUILD
+++ b/fuzzing/BUILD
@@ -57,6 +57,8 @@ string_flag(
         # Undefined Behavior sanitizer (UBSAN).
         # See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
         "ubsan",
+        # ASAN + UBSAN in a single build.
+        "asan-ubsan",
     ],
     visibility = ["//visibility:public"],
 )

--- a/fuzzing/instrum_opts.bzl
+++ b/fuzzing/instrum_opts.bzl
@@ -45,4 +45,5 @@ sanitizer_configs = {
     "msan": instrum_defaults.msan,
     "msan-origin-tracking": instrum_defaults.msan_origin_tracking,
     "ubsan": instrum_defaults.ubsan,
+    "asan-ubsan": instrum_opts.merge(instrum_defaults.asan, instrum_defaults.ubsan),
 }


### PR DESCRIPTION
This option combines ASan with UBSan, which is very useful for running the replay tests as well as while iterating on a fuzz test locally.