### PR TITLE
Fix `main_class` error in `java_fuzz_test`

### DIFF
--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -292,6 +292,7 @@ def java_fuzz_test(
 
     native.java_binary(
         name = metadata_binary_name,
+        create_executable = False,
         deploy_manifest_lines = [target_class_manifest_line],
         tags = ["manual"],
     )


### PR DESCRIPTION
In certain situations, `java_fuzz_test`s failed with

```
ERROR: Projects/fuzz-sample/BUILD:3:15: in java_binary rule //:JavaFuzzTest_metadata_: need at least one of 'main_class' or Java source files
ERROR: Projects/fuzz-sample/BUILD:3:15: in java_binary rule //:JavaFuzzTest_metadata_: main_class was not provided and cannot be inferred: source path doesn't include a known root (java, javatests, src, testsrc)
ERROR: Projects/fuzz-sample/BUILD:3:15: Analysis of target '//:JavaFuzzTest_metadata_' failed
```

This is fixed by marking the metadata jar as non-executable.

Fixes #235