### PR TITLE
Update abseil-cpp to fix build with Clang >=16

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,9 @@
 build --action_env=CC=clang-10
 build --action_env=CXX=clang++-10
 
+# Needed for abseil-cpp until https://github.com/bazelbuild/bazel/pull/19794 is released.
+build --cxxopt=-std=c++14
+
 # Workaround for https://github.com/bazelbuild/bazel/issues/3236
 build --sandbox_tmpfs_path=/tmp
 

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -55,9 +55,9 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = True)
     maybe(
         http_archive,
         name = "com_google_absl",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/f2dbd918d8d08529800eb72f23bd2829f92104a4.zip"],
-        strip_prefix = "abseil-cpp-f2dbd918d8d08529800eb72f23bd2829f92104a4",
-        sha256 = "5e1cbf25bf501f8e37866000a6052d02dbdd7b19a5b592251c59a4c9aa5c71ae",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip"],
+        strip_prefix = "abseil-cpp-20230802.1",
+        sha256 = "497ebdc3a4885d9209b9bd416e8c3f71e7a1fb8af249f6c2a80b7cbeefcd7e21",
     )
 
     if oss_fuzz:


### PR DESCRIPTION
NOTE: abseil-cpp started requiring C++14 in the 2023 January LTS release, so if this is merged, users on [old compilers](https://github.com/google/oss-policies-info/blob/b842c39db88e6569dfe2cf98be434b03507cb503/foundational-cxx-support-matrix.md) may have to override abseil-cpp to an older version.

This fixes a build error in newer Clang caused by a
feature=layering_check violation:

```
In file included from external/com_google_absl/absl/debugging/stacktrace.cc:46:
external/com_google_absl/absl/debugging/internal/stacktrace_x86-inl.inc:38:10: error: module @com_google_absl//absl/debugging:stacktrace does not depend on a module exporting 'absl/base/internal/raw_logging.h'
         ^
1 error generated.
```

This commit in abseil-cpp fixing the error is `https://github.com/abseil/abseil-cpp/commit/f753eb27d03c9900aa65c4568c0420334cd28aab`.