### PR TITLE
Fix import to include full path

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,10 @@ load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 
 rules_fuzzing_dependencies()
 
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
 
 rules_fuzzing_init()

--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -39,9 +39,9 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = True)
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
-        strip_prefix = "rules_python-0.20.0",
-        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.20.0.tar.gz",
+        sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
+        strip_prefix = "rules_python-0.26.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
     )
     maybe(
         http_archive,

--- a/fuzzing/requirements.txt
+++ b/fuzzing/requirements.txt
@@ -1,5 +1,5 @@
 # Python requirements for the tools supporting the fuzzing rules. These are
 # installed automatically through the WORKSPACE configuration.
 
-absl-py==0.11.0 --hash=sha256:b3d9eb5119ff6e0a0125f6dabf2f9fae02f8acae7be70576002fac27235611c5
-six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3
+six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/fuzzing/tools/validate_dict.py
+++ b/fuzzing/tools/validate_dict.py
@@ -19,7 +19,7 @@ Validates and merges a set of fuzzing dictionary files into a single output.
 
 from absl import app
 from absl import flags
-from dict_validation import validate_line
+from fuzzing.tools.dict_validation import validate_line
 from sys import stderr
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
This seems to be necessary for the project to build successfully with Bazel 6.

I also fixed some build errors related to Python 3.12, by upgrading to the most recent versions of absl, six, and rules_python.