### PR TITLE
Update pip_parse invocation

### DIFF
--- a/fuzzing/init.bzl
+++ b/fuzzing/init.bzl
@@ -21,6 +21,6 @@ def rules_fuzzing_init():
     pip_parse(
         name = "fuzzing_py_deps",
         extra_pip_args = ["--require-hashes"],
-        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+        requirements_lock = "@rules_fuzzing//fuzzing:requirements.txt",
     )
     bazel_skylib_workspace()


### PR DESCRIPTION
The `requirements` argument is deprecated and will be removed in the next rules_python release.

Fixes #239