### PR TITLE
Update rules_python to 0.28.0

### DIFF
--- a/fuzzing/repositories.bzl
+++ b/fuzzing/repositories.bzl
@@ -39,9 +39,9 @@ def rules_fuzzing_dependencies(oss_fuzz = True, honggfuzz = True, jazzer = True)
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
-        strip_prefix = "rules_python-0.26.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
+        sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+        strip_prefix = "rules_python-0.28.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz",
     )
     maybe(
         http_archive,


### PR DESCRIPTION
for `WORKSPACE` dependencies. `MODULE.bazel` already uses this version.