### PR TITLE
setup renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended",
     "schedule:earlyMondays"
-  ]
+  ],
+  "enabledManagers": ["github-actions"]
 }


### PR DESCRIPTION
[Renovate](https://docs.renovatebot.com/)  provides a way to receive pr when a new version is available for a dependency.

Only renovate (vs dependabot)  handle bazel dependencies .
This setup configuration dor a weekly check with renovate. It requiees to be activated on the project or organisation level to work correctly .
See [doc](https://docs.renovatebot.com/modules/platform/github/) to finalize 