### PR TITLE
fix(replayer): replay corpus files in hidden dirs

### DIFF
--- a/.github/workflows/oss_fuzz.yml
+++ b/.github/workflows/oss_fuzz.yml
@@ -40,7 +40,7 @@ jobs:
         fuzz-seconds: 60
         dry-run: false
     - name: Upload crashes
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts
@@ -66,7 +66,7 @@ jobs:
         fuzz-seconds: 60
         dry-run: false
     - name: Upload crashes
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/fuzzing/replay/file_util.cc
+++ b/fuzzing/replay/file_util.cc
@@ -53,10 +53,11 @@ absl::Status TraverseDirectory(
       }
       break;
     }
-    if (absl::StartsWith(entry->d_name, ".")) {
+    auto entry_name = absl::string_view(entry->d_name);
+    if (entry_name == "." || entry_name == "..") {
       continue;
     }
-    const std::string entry_path = absl::StrCat(path, "/", entry->d_name);
+    const std::string entry_path = absl::StrCat(path, "/", entry_name);
     status.Update(YieldFiles(entry_path, callback));
   }
   closedir(dir);

--- a/fuzzing/replay/file_util_test.cc
+++ b/fuzzing/replay/file_util_test.cc
@@ -97,6 +97,22 @@ TEST(YieldFilesTest, YieldsDeepFiles) {
   EXPECT_THAT(collected_paths, testing::SizeIs(4));
 }
 
+TEST(YieldFilesTest, YieldsHiddenFilesAndDirs) {
+  const std::string root_dir =
+      absl::StrCat(getenv("TEST_TMPDIR"), "/dir-with-hidden");
+  ASSERT_EQ(mkdir(root_dir.c_str(), 0755), 0);
+  ASSERT_TRUE(SetFileContents(absl::StrCat(root_dir, "/.a"), "foo").ok());
+  const std::string child_dir = absl::StrCat(root_dir, "/.hidden");
+  ASSERT_EQ(mkdir(child_dir.c_str(), 0755), 0);
+  ASSERT_TRUE(SetFileContents(absl::StrCat(child_dir, "/b"), "bar").ok());
+
+  std::vector<std::string> collected_paths;
+  const absl::Status status =
+      YieldFiles(root_dir, CollectPathsCallback(&collected_paths));
+  EXPECT_TRUE(status.ok());
+  EXPECT_THAT(collected_paths, testing::SizeIs(2));
+}
+
 }  // namespace
 
 }  // namespace fuzzing


### PR DESCRIPTION
The replayer would not execute hidden corpus files or files in hidden directories if they were in the bazel project root (#253).