### PR TITLE
Add shebang onto the regression script.

### DIFF
--- a/fuzzing/private/common.bzl
+++ b/fuzzing/private/common.bzl
@@ -20,7 +20,7 @@ def _fuzzing_launcher_script(ctx):
     binary_info = ctx.attr.binary[FuzzingBinaryInfo]
     script = ctx.actions.declare_file(ctx.label.name)
 
-    script_template = """
+    script_template = """#!/usr/bin/env bash
 {environment}
 echo "Launching {binary_path} as a {engine_name} fuzz test..."
 RUNFILES_DIR="$0.runfiles" \

--- a/fuzzing/private/regression.bzl
+++ b/fuzzing/private/regression.bzl
@@ -19,7 +19,7 @@ load("//fuzzing/private:binary.bzl", "FuzzingBinaryInfo")
 def _fuzzing_regression_test_impl(ctx):
     binary_info = ctx.attr.binary[FuzzingBinaryInfo]
     script = ctx.actions.declare_file(ctx.label.name)
-    script_template = """
+    script_template = """#!/usr/bin/env bash
 export FUZZER_OUTPUT_CORPUS_DIR="$TEST_TMPDIR/corpus"
 export FUZZER_ARTIFACTS_DIR="$TEST_TMPDIR/artifacts"
 export FUZZER_BINARY='{fuzzer_binary}'


### PR DESCRIPTION
The fuzzing script, as it stands right now, works fine if run directly, but can encounter issues if used with `--run_under`. By adding a shebang at the top, it can be used more flexibly.